### PR TITLE
Auto-return preview after live edits

### DIFF
--- a/server/codex_bridge/config.py
+++ b/server/codex_bridge/config.py
@@ -57,7 +57,8 @@ Context and tool usage:
 - live mode turn input already includes the current preview image
 - turn input already includes the current editable settings and luma histogram snapshot
 - call `get_image_state` only when you need refreshed exact state after edits or when state may have changed
-- call `get_preview_image` when you need a refreshed visual check (especially after `apply_operations`)
+- `apply_operations` returns the refreshed preview image automatically after successful edits
+- call `get_preview_image` only when you need another visual check without applying new edits
 - in live agent runs (`mode=multi-turn`), call `apply_operations` to apply edits iteratively
 Return exactly one JSON object matching the output schema after tool calls.
 

--- a/server/codex_bridge/operations.py
+++ b/server/codex_bridge/operations.py
@@ -120,9 +120,13 @@ class OperationsMixin:
                     "text": (
                         f"Applied {len(applied_batch)} operations in this call; "
                         f"{len(context.applied_operations)} total live edits applied. "
-                        "Preview refreshed for get_preview_image."
+                        "Refreshed preview image included below."
                     ),
-                }
+                },
+                {
+                    "type": "inputImage",
+                    "imageUrl": context.preview_data_url,
+                },
             ],
         }
 

--- a/server/codex_bridge/prompting.py
+++ b/server/codex_bridge/prompting.py
@@ -278,7 +278,7 @@ class PromptingMixin:
         live_run_line = (
             "Live run mode is enabled: use apply_operations for iterative edits inside this same run.\n"
             "Initial turn input includes the current preview image plus the current editable settings and luma histogram snapshot.\n"
-            "After each apply_operations call, re-check get_image_state and optionally get_preview_image before the next adjustment.\n"
+            "After each apply_operations call, inspect the refreshed preview image returned in that tool response and re-check get_image_state when you need refreshed exact state before the next adjustment.\n"
             f"Apply at least one edit batch with apply_operations within the first {_DEFAULT_MAX_TOOL_CALLS_WITHOUT_APPLY} tool calls.\n"
             "When satisfied, return final JSON with continueRefining=false and usually empty operations.\n"
             if live_run_enabled
@@ -294,7 +294,7 @@ class PromptingMixin:
             "\n"
             "Use read-only tools only when needed for missing context.\n"
             "Initial turn input already includes the current editable settings, luma histogram snapshot, and in live mode the current preview image.\n"
-            "Use get_image_state mainly after apply_operations when you need refreshed exact state; use get_preview_image mainly after apply_operations for refreshed visual checks.\n"
+            "Use get_image_state mainly after apply_operations when you need refreshed exact state; the refreshed preview image is returned directly by successful apply_operations calls, so use get_preview_image only for extra visual checks between edit batches.\n"
             "Use only the tool-provided editable settings and image state.\n"
             f"{live_run_line}"
             "Use moduleId/moduleLabel from the provided image state to group related controls.\n"

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -545,6 +545,10 @@ def test_turn_prompt_tells_codex_to_infer_broad_edit_plan_from_visual_context() 
         in prompt
     )
     assert (
+        "After each apply_operations call, inspect the refreshed preview image returned in that tool response"
+        in prompt
+    )
+    assert (
         "Apply at least one edit batch with apply_operations within the first" in prompt
     )
     assert "infer a conservative supported edit plan" in prompt
@@ -1020,7 +1024,14 @@ def test_apply_operations_tool_updates_state_and_stages_operations() -> None:
         result = sent_payloads[0]["result"]
         assert result["success"] is True
         assert "Applied 1 operations" in result["contentItems"][0]["text"]
-        assert "Preview refreshed" in result["contentItems"][0]["text"]
+        assert (
+            "Refreshed preview image included below"
+            in result["contentItems"][0]["text"]
+        )
+        assert result["contentItems"][1]["type"] == "inputImage"
+        auto_preview = result["contentItems"][1]["imageUrl"]
+        assert auto_preview != preview_before
+        assert "x-darktable-stage=1" in auto_preview
 
         sent_payloads.clear()
         bridge._handle_server_request_locked(  # type: ignore[attr-defined]
@@ -1168,6 +1179,10 @@ def test_apply_operations_tool_applies_white_balance_batch_in_stable_order(
     result = sent_payloads[0]["result"]
     assert result["success"] is True
     assert "Applied 3 operations" in result["contentItems"][0]["text"]
+    assert result["contentItems"][1]["type"] == "inputImage"
+    assert result["contentItems"][1]["imageUrl"].endswith(
+        "x-darktable-stage=3;base64,ZmFrZS1wcmV2aWV3"
+    )
 
     assert white_balance_logs
     structured = white_balance_logs[-1]


### PR DESCRIPTION
## What changed

- make successful `apply_operations` tool calls return the refreshed preview image directly in the same tool response
- update live-run prompt guidance so Codex treats that returned image as the primary visual feedback after each edit batch
- keep `get_preview_image` available for extra visual checks between edit batches, but no longer require it immediately after every apply
- add server tests covering the new auto-preview behavior for both general live edits and white-balance edit batches

## Why

- the live agent already refreshes preview state after each edit batch, so surfacing that refreshed preview immediately reduces unnecessary tool calls and shortens the edit loop

## Verification

- `uvx pyright server shared`
- `uv run pytest server/tests`
- `uvx pre-commit run --all-files`
