### PR TITLE
Add bootstrap command for cross-platform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ In live mode, the backend can stage multiple edit batches, refresh state and pre
 
 Prerequisites:
 
-- Linux
+- macOS or Linux
 - `python3` 3.14+
 - `uv`
 - `codex` CLI installed and authenticated
-- darktable build dependencies for your distribution
-- local CLI tools used by the build and test scripts: `ninja`, `curl`, GNU `timeout`
-- optional: `xvfb-run` for headless smoke tests
+- macOS: Homebrew
+- Linux: darktable build dependencies for your distribution
+- local CLI tools used by the build and test scripts: `ninja`, `cmake`, `curl`
+- optional: `xvfb-run` for headless smoke tests (Linux)
 
-Install Python dependencies:
+Install all dependencies (Homebrew packages on macOS, Python packages on all platforms):
 
 ```bash
-uv sync --extra dev
+npm run bootstrap
 ```
 
 Build darktable:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "darktable-agent",
   "private": true,
   "scripts": {
+    "bootstrap": "./scripts/install.sh",
     "build:serve": "npm run darktable:build-and-start && npm run server:start",
     "darktable:build": "./scripts/build_darktable_local.sh",
     "darktable:start": "./scripts/run_darktable_local.sh",

--- a/scripts/build_darktable_local.sh
+++ b/scripts/build_darktable_local.sh
@@ -10,7 +10,7 @@ BUILD_DIR="${BUILD_DIR:-$DARKTABLE_DIR/build-5.4.1}"
 INSTALL_PREFIX="${INSTALL_PREFIX:-$DARKTABLE_DIR/.install-5.4.1}"
 BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
 BUILD_GENERATOR="${BUILD_GENERATOR:-Ninja}"
-JOBS="${JOBS:-$(nproc)}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}"
 
 exec "$DARKTABLE_DIR/build.sh" \
   --build-generator "$BUILD_GENERATOR" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd -P)
+
+info()  { printf '\033[36m[INFO]\033[0m %s\n' "$1"; }
+warn()  { printf '\033[33m[WARN]\033[0m %s\n' "$1"; }
+error() { printf '\033[31m[ERROR]\033[0m %s\n' "$1"; }
+
+OS="$(uname -s)"
+
+install_macos_deps() {
+  if ! command -v brew &>/dev/null; then
+    error "Homebrew is required but not found. Install it from https://brew.sh/"
+    exit 1
+  fi
+  info "Installing darktable build dependencies via Homebrew..."
+
+  local deps=(
+    cmake
+    ninja
+    pkg-config
+    curl
+    desktop-file-utils
+    exiv2
+    gettext
+    glib
+    gtk-mac-integration
+    gtk+3
+    icu4c
+    intltool
+    iso-codes
+    jpeg-turbo
+    lensfun
+    libomp
+    librsvg
+    little-cms2
+    llvm
+    lua
+    openexr
+    perl
+    pugixml
+    sdl2
+    graphicsmagick
+    gphoto2
+    webp
+    libavif
+    libraw
+    libsecret
+    sqlite
+    portmidi
+    po4a
+    adwaita-icon-theme
+    json-glib
+  )
+
+  local missing=()
+  local installed
+  installed=$(brew list --formula --quiet)
+
+  for dep in "${deps[@]}"; do
+    if ! echo "$installed" | grep -qx "$dep"; then
+      missing+=("$dep")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    info "Installing missing packages: ${missing[*]}"
+    brew install "${missing[@]}"
+  else
+    info "All Homebrew dependencies already installed."
+  fi
+
+  brew link --force libomp 2>/dev/null || true
+}
+
+install_linux_deps() {
+  info "On Linux, install darktable build dependencies using your package manager."
+  info "Examples:"
+  info "  Fedora/RHEL:   sudo dnf builddep darktable"
+  info "  Ubuntu/Debian: sudo apt-get build-dep darktable"
+  info "  OpenSuse:      sudo zypper si -d darktable"
+  info "Also ensure ninja and cmake are installed."
+}
+
+install_python_deps() {
+  if ! command -v uv &>/dev/null; then
+    error "'uv' is required but not found. Install it from https://docs.astral.sh/uv/"
+    exit 1
+  fi
+  info "Installing Python dependencies with uv..."
+  cd "$REPO_ROOT"
+  uv sync --extra dev
+}
+
+info "Detected OS: $OS"
+
+case "$OS" in
+  Darwin)
+    install_macos_deps
+    ;;
+  Linux)
+    install_linux_deps
+    ;;
+  *)
+    warn "Unsupported OS '$OS'. Skipping system dependency installation."
+    ;;
+esac
+
+install_python_deps
+
+info "Setup complete. Next steps:"
+info "  npm run darktable:build   # build darktable"
+info "  npm run server:start      # start the backend"
+info "  npm run darktable:start   # start darktable"

--- a/scripts/run_darktable_local.sh
+++ b/scripts/run_darktable_local.sh
@@ -40,7 +40,7 @@ cmd=(
   --configdir "$CONFIG_DIR"
   --cachedir "$CACHE_DIR"
   --library "$DARKTABLE_LIBRARY_FILE"
-  "${args[@]}"
+  ${args[@]+"${args[@]}"}
 )
 
 if [[ "$FOREGROUND" == "1" ]]; then


### PR DESCRIPTION
Adds `npm run bootstrap` to install all dependencies for darktable and the agent server on macOS and Linux.

### Changes
- **`scripts/install.sh`**: Cross-platform install script. Installs Homebrew deps on macOS, prints package manager guidance on Linux, runs `uv sync --extra dev` on both.
- **`package.json`**: Added `bootstrap` script.
- **`scripts/build_darktable_local.sh`**: Fixed Linux-only `nproc` with macOS fallback (`sysctl -n hw.logicalcpu`).
- **`scripts/run_darktable_local.sh`**: Fixed `args[@]: unbound variable` crash when no extra args are passed with `set -u`.
- **`README.md`**: Updated setup section to reflect macOS support and the new bootstrap command.