### PR TITLE
Apply live edits stepwise in darkroom runs

### DIFF
--- a/server/codex_bridge/models.py
+++ b/server/codex_bridge/models.py
@@ -73,6 +73,7 @@ class TurnContext:
     rendered_preview_bytes: bytes | None = None
     requires_render_callback: bool = False
     last_applied_batch: list[dict[str, Any]] = field(default_factory=list)
+    last_applied_summary: str | None = None
     last_verifier_status: str | None = None
     last_verifier_summary: str | None = None
 

--- a/server/codex_bridge/operations.py
+++ b/server/codex_bridge/operations.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 # pyright: reportAttributeAccessIssue=false
 
 import copy
-import io
 import json
 from typing import Any
 
@@ -18,6 +17,9 @@ class OperationsMixin:
         self,
         context: TurnContext,
         arguments: dict[str, Any],
+        *,
+        thread_id: str | None = None,
+        turn_id: str | None = None,
     ) -> dict[str, Any]:
         if not context.live_run_enabled:
             return self._tool_error_response(
@@ -74,12 +76,14 @@ class OperationsMixin:
                     error=apply_error,
                 )
                 return self._tool_error_response(apply_error)
-
         applied_batch: list[dict[str, Any]] = []
-        for operation in ordered_batch:
-            apply_error, _ = self._apply_operation_to_settings(
-                context.setting_by_id, operation
-            )
+        step_summaries: list[str] = []
+        latest_preview_url: str | None = None
+        latest_verifier_result: dict[str, Any] | None = None
+        render_warnings: list[str] = []
+
+        for step_index, operation in enumerate(ordered_batch, start=1):
+            apply_error = self._apply_live_operation_step(context, operation)
             if apply_error:
                 self._log_white_balance_tool_call(
                     context,
@@ -89,11 +93,81 @@ class OperationsMixin:
                     error=apply_error,
                 )
                 return self._tool_error_response(apply_error)
-            applied_batch.append(operation)
-            context.applied_operations.append(operation)
 
-        context.next_operation_sequence += len(applied_batch)
-        context.last_applied_batch = list(applied_batch)
+            applied_batch.append(operation)
+            step_summary = self._summarize_live_operation(context, operation)
+            step_summaries.append(step_summary)
+            context.last_applied_summary = step_summary
+
+            if thread_id and turn_id:
+                self._set_active_request_status_for_turn_locked(
+                    thread_id,
+                    turn_id,
+                    status="running",
+                    message=(
+                        f"Applied live edit step {step_index}/{len(ordered_batch)}: "
+                        f"{step_summary}"
+                    ),
+                    last_tool_name=_TOOL_APPLY_OPERATIONS,
+                )
+
+            preview_url, verifier_result, warning = self._wait_for_live_render(context)
+            if preview_url is not None:
+                latest_preview_url = preview_url
+            if verifier_result is not None:
+                latest_verifier_result = verifier_result
+            if warning is not None:
+                render_warnings.append(warning)
+        self._log_white_balance_tool_call(
+            context,
+            ordered_batch,
+            applied_batch,
+            success=True,
+        )
+
+        content_items: list[dict[str, Any]] = [
+            {
+                "type": "inputText",
+                "text": (
+                    f"Applied {len(applied_batch)} operations stepwise in this call; "
+                    f"{len(context.applied_operations)} total live edits applied. "
+                    f"Steps: {'; '.join(step_summaries)}. "
+                    "Refreshed preview image included below."
+                ),
+            }
+        ]
+        if latest_preview_url is not None:
+            content_items.append(
+                {
+                    "type": "inputImage",
+                    "imageUrl": latest_preview_url,
+                }
+            )
+        for warning in render_warnings:
+            content_items.append({"type": "inputText", "text": warning})
+        if latest_verifier_result is not None:
+            content_items.append(
+                {
+                    "type": "inputText",
+                    "text": self._verifier_feedback_text(latest_verifier_result),
+                }
+            )
+        return {"success": True, "contentItems": content_items}
+
+    def _apply_live_operation_step(
+        self,
+        context: TurnContext,
+        operation: dict[str, Any],
+    ) -> str | None:
+        apply_error, _ = self._apply_operation_to_settings(
+            context.setting_by_id, operation
+        )
+        if apply_error:
+            return apply_error
+
+        context.applied_operations.append(operation)
+        context.next_operation_sequence += 1
+        context.last_applied_batch = [operation]
         image_snapshot = context.state_payload.get("imageSnapshot")
         if isinstance(image_snapshot, dict):
             image_snapshot["imageRevisionId"] = (
@@ -103,26 +177,88 @@ class OperationsMixin:
         context.requires_render_callback = True
         context.render_event.clear()
         context.rendered_preview_bytes = None
-        self._log_white_balance_tool_call(
-            context,
-            ordered_batch,
-            applied_batch,
-            success=True,
-        )
+        return None
 
-        return {
-            "success": True,
-            "contentItems": [
-                {
-                    "type": "inputText",
-                    "text": (
-                        f"Applied {len(applied_batch)} operations in this call; "
-                        f"{len(context.applied_operations)} total live edits applied. "
-                        "Refreshed preview image included below."
-                    ),
+    def _wait_for_live_render(
+        self, context: TurnContext
+    ) -> tuple[str | None, dict[str, Any] | None, str | None]:
+        logger.info(
+            "waiting_for_mid_turn_render",
+            extra={
+                "structured": {
+                    "threadId": context.base_request.session.conversationId,
+                    "turnId": context.base_request.session.turnId,
                 }
-            ],
-        }
+            },
+        )
+        render_arrived = context.render_event.wait(timeout=15.0)
+        context.requires_render_callback = False
+        rendered_bytes = context.rendered_preview_bytes
+        context.rendered_preview_bytes = None
+
+        if render_arrived and rendered_bytes:
+            context.preview_mime_type = "image/jpeg"
+            context.current_preview_bytes = rendered_bytes
+            context.preview_data_url = self._build_data_url(
+                "image/jpeg",
+                rendered_bytes,
+                revision_token=str(len(context.applied_operations)),
+            )
+            verifier_result = self._build_live_verifier_feedback(context)
+            return context.preview_data_url, verifier_result, None
+
+        warning = "Warning: mid-turn render timed out. The preview image may be stale."
+        logger.warning(
+            "mid_turn_render_timeout",
+            extra={
+                "structured": {
+                    "conversationId": context.base_request.session.conversationId,
+                    "turnId": context.base_request.session.turnId,
+                }
+            },
+        )
+        return None, None, warning
+
+    def _summarize_live_operation(
+        self,
+        context: TurnContext,
+        operation: dict[str, Any],
+    ) -> str:
+        target = operation.get("target")
+        target_dict = target if isinstance(target, dict) else {}
+        action_path = str(target_dict.get("actionPath") or "unknown")
+        setting_id = str(target_dict.get("settingId") or "")
+        setting = context.setting_by_id.get(setting_id, {})
+        module_label = str(setting.get("moduleLabel") or "")
+        control_label = str(setting.get("label") or action_path.rsplit("/", 1)[-1])
+        label = " / ".join(part for part in (module_label, control_label) if part)
+        if not label:
+            label = action_path
+
+        value = operation.get("value")
+        if not isinstance(value, dict):
+            return label
+
+        kind = operation.get("kind")
+        if kind == "set-float":
+            number = value.get("number")
+            mode = value.get("mode")
+            if isinstance(number, (int, float)):
+                if mode == "delta":
+                    return f"{label} {float(number):+0.3f}"
+                return f"{label} = {float(number):0.3f}"
+        if kind == "set-choice":
+            choice_id = value.get("choiceId")
+            choice_value = value.get("choiceValue")
+            if isinstance(choice_id, str) and choice_id:
+                return f"{label} -> {choice_id}"
+            if isinstance(choice_value, int):
+                return f"{label} -> choice {choice_value}"
+        if kind == "set-bool":
+            bool_value = value.get("boolValue")
+            if isinstance(bool_value, bool):
+                return f"{label} -> {'on' if bool_value else 'off'}"
+        return label
 
     @staticmethod
     def _clamp(value: float, minimum: float, maximum: float) -> float:

--- a/server/codex_bridge/prompting.py
+++ b/server/codex_bridge/prompting.py
@@ -351,6 +351,7 @@ class PromptingMixin:
         if live_run_enabled:
             mode_block = (
                 "Live run mode is enabled: use apply_operations for iterative edits inside this same run.\n"
+                "Inside each apply_operations call, operations are auto-applied one at a time with a fresh render after each step.\n"
                 "Turn input includes the current preview image, editable settings, and histogram.\n"
                 "After each apply_operations call, inspect the refreshed preview and re-check get_image_state when you need refreshed exact state.\n"
                 f"Apply at least one edit batch within the first {_DEFAULT_MAX_TOOL_CALLS_WITHOUT_APPLY + 2} tool calls.\n"

--- a/server/codex_bridge/tool_routing.py
+++ b/server/codex_bridge/tool_routing.py
@@ -48,7 +48,7 @@ class ToolRoutingMixin:
             },
             {
                 "name": _TOOL_APPLY_OPERATIONS,
-                "description": "Apply one or more darktable operations in the live run and update image state for follow-up tool calls.",
+                "description": "Apply darktable operations in the live run. Operations are auto-applied one at a time with a fresh render after each step so the user can see every change.",
                 "inputSchema": apply_operations_schema,
             },
         ]
@@ -125,38 +125,46 @@ class ToolRoutingMixin:
             guardrail_error = self._register_tool_call_progress_locked(
                 context, tool_name
             )
-            if guardrail_error is not None:
-                response = self._tool_error_response(guardrail_error)
-            elif tool_name == _TOOL_GET_PREVIEW_IMAGE:
-                response = {
-                    "success": True,
-                    "contentItems": [
-                        {"type": "inputImage", "imageUrl": context.preview_data_url}
-                    ],
-                }
-            elif tool_name == _TOOL_GET_IMAGE_STATE:
-                response = {
-                    "success": True,
-                    "contentItems": [
-                        {
-                            "type": "inputText",
-                            "text": json.dumps(
-                                context.state_payload, separators=(",", ":")
-                            ),
-                        }
-                    ],
-                }
-            elif tool_name == _TOOL_APPLY_OPERATIONS:
-                response = self._apply_operations_tool_call(context, arguments)
-            else:
-                response = self._tool_error_response(
-                    f"Unsupported tool '{tool_name}'. Supported tools: {_TOOL_GET_PREVIEW_IMAGE}, {_TOOL_GET_IMAGE_STATE}, {_TOOL_APPLY_OPERATIONS}."
-                )
 
+        if guardrail_error is not None:
+            response = self._tool_error_response(guardrail_error)
+        elif tool_name == _TOOL_GET_PREVIEW_IMAGE:
+            response = {
+                "success": True,
+                "contentItems": [
+                    {"type": "inputImage", "imageUrl": context.preview_data_url}
+                ],
+            }
+        elif tool_name == _TOOL_GET_IMAGE_STATE:
+            response = {
+                "success": True,
+                "contentItems": [
+                    {
+                        "type": "inputText",
+                        "text": json.dumps(
+                            context.state_payload, separators=(",", ":")
+                        ),
+                    }
+                ],
+            }
+        elif tool_name == _TOOL_APPLY_OPERATIONS:
+            response = self._apply_operations_tool_call(
+                context,
+                arguments,
+                thread_id=thread_id,
+                turn_id=turn_id,
+            )
+        else:
+            response = self._tool_error_response(
+                f"Unsupported tool '{tool_name}'. Supported tools: {_TOOL_GET_PREVIEW_IMAGE}, {_TOOL_GET_IMAGE_STATE}, {_TOOL_APPLY_OPERATIONS}."
+            )
+
+        with self._state_lock:
             tool_calls_used = context.tool_calls_used
             max_tool_calls = context.max_tool_calls
             applied_operation_count = len(context.applied_operations)
             read_only_streak = context.consecutive_read_only_tool_calls
+            last_applied_summary = context.last_applied_summary
             tool_error = None
             if not response["success"]:
                 content_items = response.get("contentItems")
@@ -175,6 +183,11 @@ class ToolRoutingMixin:
             status="running",
             message=(
                 f"Handled tool {tool_name} ({tool_calls_used}/{max_tool_calls}); {applied_operation_count} live edits"
+                + (
+                    f". Latest step: {last_applied_summary}"
+                    if tool_name == _TOOL_APPLY_OPERATIONS and last_applied_summary
+                    else ""
+                )
                 if response["success"]
                 else f"Tool {tool_name} failed ({tool_calls_used}/{max_tool_calls}): {tool_error or 'No details provided'}"
             ),
@@ -199,7 +212,10 @@ class ToolRoutingMixin:
             },
         )
 
-        requires_render = getattr(context, "requires_render_callback", False)
+        requires_render = (
+            getattr(context, "requires_render_callback", False)
+            and tool_name != _TOOL_APPLY_OPERATIONS
+        )
         if requires_render:
             logger.info(
                 "waiting_for_mid_turn_render",

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -605,6 +605,7 @@ def test_turn_prompt_tells_codex_to_infer_broad_edit_plan_from_visual_context() 
     assert "Turn input includes the current preview image" in prompt
     assert "compact analysis signals" in prompt
     assert "apply_operations returns the refreshed preview automatically" in prompt
+    assert "operations are auto-applied one at a time" in prompt
     assert "Do not introduce new operations in the final JSON" in prompt
     assert "do not stop at basic exposure/contrast edits" in prompt
     assert "Apply at least one edit batch within the first" in prompt

--- a/server/tests/test_smoke.py
+++ b/server/tests/test_smoke.py
@@ -354,6 +354,74 @@ def test_sequential_applies_update_preview_each_time(
     assert preview_1 != preview_2
 
 
+def test_batched_apply_renders_after_each_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _sample_request(live_run=True)
+    bridge, sent = _init_bridge_with_context(request)
+    context = bridge._get_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+    assert context is not None
+
+    render_payloads = [b"rendered-step-1", b"rendered-step-2"]
+    wait_calls: list[float | None] = []
+
+    def _mock_wait(timeout=None):
+        wait_calls.append(timeout)
+        context.rendered_preview_bytes = render_payloads[len(wait_calls) - 1]
+        return True
+
+    monkeypatch.setattr(context.render_event, "wait", _mock_wait)
+
+    bridge._handle_server_request_locked(  # type: ignore[attr-defined]
+        {
+            "jsonrpc": "2.0",
+            "id": 77,
+            "method": "item/tool/call",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "callId": "call-batch-stepwise",
+                "tool": _TOOL_APPLY_OPERATIONS,
+                "arguments": {
+                    "operations": [
+                        {
+                            "kind": "set-float",
+                            "target": {
+                                "type": "darktable-action",
+                                "actionPath": "iop/exposure/exposure",
+                                "settingId": "setting.exposure.primary",
+                            },
+                            "value": {"mode": "delta", "number": 0.2},
+                        },
+                        {
+                            "kind": "set-float",
+                            "target": {
+                                "type": "darktable-action",
+                                "actionPath": "iop/exposure/exposure",
+                                "settingId": "setting.exposure.primary",
+                            },
+                            "value": {"mode": "delta", "number": 0.1},
+                        },
+                    ]
+                },
+            },
+        }
+    )
+
+    result = sent[0]["result"]
+    assert result["success"] is True
+    assert len(wait_calls) == 2
+    assert "Applied 2 operations stepwise" in result["contentItems"][0]["text"]
+    assert result["contentItems"][1]["type"] == "inputImage"
+    assert "x-darktable-stage=2" in result["contentItems"][1]["imageUrl"]
+    encoded_rendered = base64.b64encode(render_payloads[-1]).decode()
+    assert result["contentItems"][1]["imageUrl"].endswith(f";base64,{encoded_rendered}")
+    assert len(context.applied_operations) == 2
+    assert context.setting_by_id["setting.exposure.primary"][
+        "currentNumber"
+    ] == pytest.approx(0.3)
+
+
 def test_live_verifier_flags_highlight_regression(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- apply live edit batches one operation at a time so each change is rendered and surfaced incrementally during a live run
- keep the latest live step visible in prompt/tool feedback and return a refreshed preview plus verifier feedback after stepwise applies
- add regression coverage for per-operation render waits and updated live-mode prompt guidance

## Validation
- uv run pytest server/tests
- uvx pre-commit run --all-files
- uvx pyright server shared