### PR TITLE
Track upstream darktable releases

### DIFF
--- a/.github/workflows/darktable-upstream-watch.yml
+++ b/.github/workflows/darktable-upstream-watch.yml
@@ -1,0 +1,70 @@
+name: Watch darktable upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 14 * * 1'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-upstream-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare tracked tag to upstream latest release
+        id: compare
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import urllib.request
+          from pathlib import Path
+
+          config = json.loads(Path("darktable-upstream.json").read_text())
+          current_tag = config["trackedTag"]
+          api_url = "https://api.github.com/repos/darktable-org/darktable/releases/latest"
+          request = urllib.request.Request(
+              api_url,
+              headers={"Accept": "application/vnd.github+json"},
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              latest = json.load(response)["tag_name"]
+
+          print(f"current_tag={current_tag}")
+          print(f"latest_tag={latest}")
+          print(f"has_update={'true' if latest != current_tag else 'false'}")
+          PY
+
+      - name: Open or update upstream sync issue
+        if: steps.compare.outputs.has_update == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ steps.compare.outputs.current_tag }}
+          LATEST_TAG: ${{ steps.compare.outputs.latest_tag }}
+        run: |
+          title="Sync darktable upstream to ${LATEST_TAG}"
+          body=$(cat <<EOF
+          darktable upstream has published a newer release.
+
+          - Current tracked tag: `${CURRENT_TAG}`
+          - Latest upstream tag: `${LATEST_TAG}`
+
+          Suggested next steps:
+
+          1. Create a sync branch from `main`
+          2. Run `python3 scripts/darktable_upstream.py status --tag ${LATEST_TAG}`
+          3. Update the vendored `darktable/` tree
+          4. Refresh `darktable-upstream.json` after the sync lands
+
+          Reference: `docs/upstream-darktable.md`
+          EOF
+          )
+          existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --title "$title" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/README.md
+++ b/README.md
@@ -99,3 +99,13 @@ On macOS, run it from a logged-in desktop session so darktable can open normally
 ## Protocol
 
 Protocol details are documented in `docs/protocol-v1.md`.
+
+## Upstream darktable tracking
+
+Upstream tracking details are documented in `docs/upstream-darktable.md`.
+
+Check the vendored darktable tree against the tracked upstream release with:
+
+```bash
+npm run darktable:upstream-status
+```

--- a/darktable-upstream.json
+++ b/darktable-upstream.json
@@ -1,0 +1,37 @@
+{
+  "repository": "https://github.com/darktable-org/darktable.git",
+  "trackedTag": "release-5.4.1",
+  "compareRoot": "darktable",
+  "ignoreGlobs": [
+    ".git",
+    ".git/**",
+    ".github/**",
+    ".githooks/**",
+    ".gitattributes",
+    ".gitignore",
+    ".gitmodules",
+    ".gitpod.Dockerfile",
+    ".gitpod.yml",
+    ".install-*/**",
+    "build-*/**",
+    "packaging/**/.gitignore",
+    "src/external/**",
+    "src/tests/integration/**",
+    "tools/noise/.gitignore",
+    "src/version_gen.c"
+  ],
+  "expectedModifiedFiles": [
+    "CMakeLists.txt",
+    "src/CMakeLists.txt",
+    "src/develop/develop.h",
+    "src/iop/colorzones.c",
+    "src/iop/rgblevels.c",
+    "src/tests/CMakeLists.txt",
+    "src/views/darkroom.c"
+  ],
+  "expectedExtraGlobs": [
+    "src/common/agent_*.c",
+    "src/common/agent_*.h",
+    "src/tests/agent_catalog.c"
+  ]
+}

--- a/docs/upstream-darktable.md
+++ b/docs/upstream-darktable.md
@@ -1,0 +1,48 @@
+# Tracking Upstream darktable
+
+This repository does not need to be a GitHub fork of `darktable-org/darktable` to stay aligned with upstream. The source of truth for the vendored darktable base lives in `darktable-upstream.json`.
+
+## Current baseline
+
+- Upstream repository: `https://github.com/darktable-org/darktable.git`
+- Tracked release tag: `release-5.4.1`
+- Vendored source path in this repo: `darktable/`
+
+## How to check our downstream patch surface
+
+Run:
+
+```bash
+npm run darktable:upstream-status
+```
+
+That command clones the tracked upstream tag into a temporary directory, compares it to `darktable/`, ignores generated/build metadata, and reports whether the local tree matches upstream plus our expected downstream patch set.
+
+You can also compare against a newer tag before attempting a sync:
+
+```bash
+python3 scripts/darktable_upstream.py status --tag release-5.4.1
+```
+
+Swap in a newer upstream tag when darktable ships a new release.
+
+## How to track new upstream releases
+
+- `darktable-upstream.json` records the currently tracked upstream tag and the expected downstream patch surface.
+- `.github/workflows/darktable-upstream-watch.yml` checks the latest GitHub release from `darktable-org/darktable` on a schedule and opens or updates an issue when upstream advances.
+
+## Recommended sync workflow
+
+1. Create a branch like `sync-darktable-5.4.2`.
+2. Run `python3 scripts/darktable_upstream.py status --tag release-5.4.2` to see the delta from the new upstream release.
+3. Update the vendored `darktable/` tree to the new upstream release.
+4. Reapply or adapt only the downstream patch surface recorded in `darktable-upstream.json`.
+5. Update `darktable-upstream.json` to the new tracked tag.
+6. Run the repo validation/build flow before opening the sync PR.
+
+## Why this workflow
+
+- No GitHub fork relationship is required.
+- No persistent git remote is required for day-to-day tracking.
+- The upstream baseline stays explicit and reviewable in the repo.
+- Future sync PRs can focus on the small set of files where darktableAgent intentionally diverges from upstream.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bootstrap": "./scripts/install.sh",
     "build:serve": "npm run darktable:build-and-start && npm run server:start",
     "darktable:build": "./scripts/build_darktable_local.sh",
+    "darktable:upstream-status": "python3 ./scripts/darktable_upstream.py status",
     "darktable:start": "./scripts/run_darktable_local.sh",
     "darktable:build-and-start": "npm run darktable:build && npm run darktable:start",
     "server:start": "./scripts/run_server.sh",

--- a/scripts/darktable_upstream.py
+++ b/scripts/darktable_upstream.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import filecmp
+import fnmatch
+import json
+import shutil
+import sys
+import tempfile
+import tarfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "darktable-upstream.json"
+
+
+@dataclass(frozen=True)
+class UpstreamConfig:
+    repository: str
+    tracked_tag: str
+    compare_root: Path
+    ignore_globs: tuple[str, ...]
+    expected_modified_files: frozenset[str]
+    expected_extra_globs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CompareReport:
+    tag: str
+    modified_files: tuple[str, ...]
+    missing_files: tuple[str, ...]
+    extra_files: tuple[str, ...]
+    unexpected_modified_files: tuple[str, ...]
+    unexpected_missing_files: tuple[str, ...]
+    unexpected_extra_files: tuple[str, ...]
+
+    @property
+    def is_clean(self) -> bool:
+        return not (
+            self.unexpected_modified_files
+            or self.unexpected_missing_files
+            or self.unexpected_extra_files
+        )
+
+
+def load_config() -> UpstreamConfig:
+    payload = json.loads(CONFIG_PATH.read_text())
+    return UpstreamConfig(
+        repository=str(payload["repository"]),
+        tracked_tag=str(payload["trackedTag"]),
+        compare_root=REPO_ROOT / str(payload["compareRoot"]),
+        ignore_globs=tuple(str(value) for value in payload.get("ignoreGlobs", [])),
+        expected_modified_files=frozenset(
+            str(value) for value in payload.get("expectedModifiedFiles", [])
+        ),
+        expected_extra_globs=tuple(
+            str(value) for value in payload.get("expectedExtraGlobs", [])
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser("status")
+    status_parser.add_argument("--tag", help="Override the tracked upstream tag")
+    status_parser.add_argument(
+        "--json", action="store_true", help="Print the report as JSON"
+    )
+
+    return parser.parse_args()
+
+
+def log_step(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def build_archive_url(repository: str, tag: str) -> str:
+    repository_root = repository.removesuffix(".git").rstrip("/")
+    if not repository_root.startswith("https://github.com/"):
+        raise ValueError(f"Unsupported upstream repository: {repository}")
+    owner_repo = repository_root.removeprefix("https://github.com/")
+    return f"https://codeload.github.com/{owner_repo}/tar.gz/refs/tags/{tag}"
+
+
+def download_and_extract_archive(repository: str, tag: str, destination: Path) -> Path:
+    archive_url = build_archive_url(repository, tag)
+    archive_path = destination / "upstream.tar.gz"
+    log_step(f"Downloading {tag} source archive...")
+    with urllib.request.urlopen(archive_url, timeout=120) as response:
+        archive_path.write_bytes(response.read())
+
+    log_step("Extracting upstream archive...")
+    with tarfile.open(archive_path, mode="r:gz") as archive:
+        archive.extractall(path=destination)
+
+    extracted_roots = [path for path in destination.iterdir() if path.is_dir()]
+    if len(extracted_roots) != 1:
+        raise ValueError("Could not determine extracted upstream archive root")
+    return extracted_roots[0]
+
+
+def should_ignore(relative_path: Path, config: UpstreamConfig) -> bool:
+    relative_text = relative_path.as_posix()
+    return any(
+        fnmatch.fnmatch(relative_text, pattern) for pattern in config.ignore_globs
+    )
+
+
+def iter_files(root: Path, config: UpstreamConfig) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(root)
+        if should_ignore(relative_path, config):
+            continue
+        files.append(relative_path)
+    return sorted(files)
+
+
+def matches_expected_extra(relative_text: str, config: UpstreamConfig) -> bool:
+    return any(
+        fnmatch.fnmatch(relative_text, pattern)
+        for pattern in config.expected_extra_globs
+    )
+
+
+def compare_against_upstream(config: UpstreamConfig, tag: str) -> CompareReport:
+    temp_dir = Path(tempfile.mkdtemp(prefix="darktable-upstream-"))
+    try:
+        upstream_root = download_and_extract_archive(config.repository, tag, temp_dir)
+        log_step("Comparing local darktable tree to upstream...")
+
+        upstream_files = iter_files(upstream_root, config)
+        local_files = iter_files(config.compare_root, config)
+        upstream_set = set(upstream_files)
+        local_set = set(local_files)
+
+        modified_files: list[str] = []
+        missing_files: list[str] = []
+        extra_files: list[str] = []
+
+        for relative_path in upstream_files:
+            local_path = config.compare_root / relative_path
+            upstream_path = upstream_root / relative_path
+            relative_text = relative_path.as_posix()
+            if not local_path.exists():
+                missing_files.append(relative_text)
+                continue
+            if not filecmp.cmp(upstream_path, local_path, shallow=False):
+                modified_files.append(relative_text)
+
+        for relative_path in sorted(local_set - upstream_set):
+            extra_files.append(relative_path.as_posix())
+
+        unexpected_modified_files = sorted(
+            relative_text
+            for relative_text in modified_files
+            if relative_text not in config.expected_modified_files
+        )
+        unexpected_extra_files = sorted(
+            relative_text
+            for relative_text in extra_files
+            if not matches_expected_extra(relative_text, config)
+        )
+
+        return CompareReport(
+            tag=tag,
+            modified_files=tuple(modified_files),
+            missing_files=tuple(missing_files),
+            extra_files=tuple(extra_files),
+            unexpected_modified_files=tuple(unexpected_modified_files),
+            unexpected_missing_files=tuple(sorted(missing_files)),
+            unexpected_extra_files=tuple(unexpected_extra_files),
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def print_text_report(config: UpstreamConfig, report: CompareReport) -> None:
+    print(f"Tracked upstream tag: {config.tracked_tag}")
+    print(f"Compared tag: {report.tag}")
+    print(f"Modified upstream files: {len(report.modified_files)}")
+    print(f"Missing upstream files: {len(report.missing_files)}")
+    print(f"Local-only files: {len(report.extra_files)}")
+    print(
+        "Status: "
+        + (
+            "clean against the tracked downstream patch surface"
+            if report.is_clean
+            else "unexpected drift detected"
+        )
+    )
+
+    if report.modified_files:
+        print("\nExpected modified files:")
+        for relative_text in report.modified_files:
+            print(f"- {relative_text}")
+
+    if report.extra_files:
+        print("\nExpected local-only files:")
+        for relative_text in report.extra_files:
+            print(f"- {relative_text}")
+
+    if report.unexpected_missing_files:
+        print("\nUnexpected missing upstream files:")
+        for relative_text in report.unexpected_missing_files:
+            print(f"- {relative_text}")
+
+    if report.unexpected_modified_files:
+        print("\nUnexpected modified upstream files:")
+        for relative_text in report.unexpected_modified_files:
+            print(f"- {relative_text}")
+
+    if report.unexpected_extra_files:
+        print("\nUnexpected local-only files:")
+        for relative_text in report.unexpected_extra_files:
+            print(f"- {relative_text}")
+
+
+def print_json_report(config: UpstreamConfig, report: CompareReport) -> None:
+    payload = {
+        "trackedTag": config.tracked_tag,
+        "comparedTag": report.tag,
+        "modifiedFiles": list(report.modified_files),
+        "missingFiles": list(report.missing_files),
+        "extraFiles": list(report.extra_files),
+        "unexpectedModifiedFiles": list(report.unexpected_modified_files),
+        "unexpectedMissingFiles": list(report.unexpected_missing_files),
+        "unexpectedExtraFiles": list(report.unexpected_extra_files),
+        "isClean": report.is_clean,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config()
+
+    if args.command == "status":
+        tag = args.tag or config.tracked_tag
+        report = compare_against_upstream(config, tag)
+        if args.json:
+            print_json_report(config, report)
+        else:
+            print_text_report(config, report)
+        return 0 if report.is_clean else 1
+
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repo-native upstream tracking config, docs, and comparison script for the vendored `darktable/` tree
- add a scheduled GitHub Actions workflow that watches `darktable-org/darktable` releases and opens or updates a sync issue when upstream advances
- document and expose a local `npm run darktable:upstream-status` check, verified clean against `release-5.4.1`