### PR TITLE
Record darktable upstream provenance

### DIFF
--- a/.github/workflows/darktable-upstream-watch.yml
+++ b/.github/workflows/darktable-upstream-watch.yml
@@ -24,6 +24,7 @@ jobs:
           from pathlib import Path
 
           config = json.loads(Path("darktable-upstream.json").read_text())
+          original_base_tag = config["originalBaseTag"]
           current_tag = config["trackedTag"]
           api_url = "https://api.github.com/repos/darktable-org/darktable/releases/latest"
           request = urllib.request.Request(
@@ -33,6 +34,7 @@ jobs:
           with urllib.request.urlopen(request, timeout=30) as response:
               latest = json.load(response)["tag_name"]
 
+          print(f"original_base_tag={original_base_tag}")
           print(f"current_tag={current_tag}")
           print(f"latest_tag={latest}")
           print(f"has_update={'true' if latest != current_tag else 'false'}")
@@ -42,6 +44,7 @@ jobs:
         if: steps.compare.outputs.has_update == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          ORIGINAL_BASE_TAG: ${{ steps.compare.outputs.original_base_tag }}
           CURRENT_TAG: ${{ steps.compare.outputs.current_tag }}
           LATEST_TAG: ${{ steps.compare.outputs.latest_tag }}
         run: |
@@ -49,6 +52,7 @@ jobs:
           body=$(cat <<EOF
           darktable upstream has published a newer release.
 
+          - Original fork/base tag: `${ORIGINAL_BASE_TAG}`
           - Current tracked tag: `${CURRENT_TAG}`
           - Latest upstream tag: `${LATEST_TAG}`
 

--- a/README.md
+++ b/README.md
@@ -109,3 +109,5 @@ Check the vendored darktable tree against the tracked upstream release with:
 ```bash
 npm run darktable:upstream-status
 ```
+
+The upstream metadata distinguishes between the original fork base and the current upstream release our vendored tree matches.

--- a/darktable-upstream.json
+++ b/darktable-upstream.json
@@ -1,5 +1,6 @@
 {
   "repository": "https://github.com/darktable-org/darktable.git",
+  "originalBaseTag": "release-5.4.0",
   "trackedTag": "release-5.4.1",
   "compareRoot": "darktable",
   "ignoreGlobs": [

--- a/docs/upstream-darktable.md
+++ b/docs/upstream-darktable.md
@@ -5,7 +5,8 @@ This repository does not need to be a GitHub fork of `darktable-org/darktable` t
 ## Current baseline
 
 - Upstream repository: `https://github.com/darktable-org/darktable.git`
-- Tracked release tag: `release-5.4.1`
+- Original fork/base tag: `release-5.4.0`
+- Current matched upstream tag: `release-5.4.1`
 - Vendored source path in this repo: `darktable/`
 
 ## How to check our downstream patch surface
@@ -16,7 +17,12 @@ Run:
 npm run darktable:upstream-status
 ```
 
-That command clones the tracked upstream tag into a temporary directory, compares it to `darktable/`, ignores generated/build metadata, and reports whether the local tree matches upstream plus our expected downstream patch set.
+That command downloads the tracked upstream source archive into a temporary directory, compares it to `darktable/`, ignores generated/build metadata, and reports whether the local tree matches upstream plus our expected downstream patch set.
+
+The status output intentionally distinguishes between:
+
+- `Original base tag`: the upstream release this fork started from
+- `Tracked current-match tag`: the upstream release the current vendored tree matches now
 
 You can also compare against a newer tag before attempting a sync:
 
@@ -28,7 +34,7 @@ Swap in a newer upstream tag when darktable ships a new release.
 
 ## How to track new upstream releases
 
-- `darktable-upstream.json` records the currently tracked upstream tag and the expected downstream patch surface.
+- `darktable-upstream.json` records both the original base tag and the currently matched upstream tag, plus the expected downstream patch surface.
 - `.github/workflows/darktable-upstream-watch.yml` checks the latest GitHub release from `darktable-org/darktable` on a schedule and opens or updates an issue when upstream advances.
 
 ## Recommended sync workflow

--- a/scripts/darktable_upstream.py
+++ b/scripts/darktable_upstream.py
@@ -21,6 +21,7 @@ CONFIG_PATH = REPO_ROOT / "darktable-upstream.json"
 @dataclass(frozen=True)
 class UpstreamConfig:
     repository: str
+    original_base_tag: str
     tracked_tag: str
     compare_root: Path
     ignore_globs: tuple[str, ...]
@@ -51,6 +52,7 @@ def load_config() -> UpstreamConfig:
     payload = json.loads(CONFIG_PATH.read_text())
     return UpstreamConfig(
         repository=str(payload["repository"]),
+        original_base_tag=str(payload["originalBaseTag"]),
         tracked_tag=str(payload["trackedTag"]),
         compare_root=REPO_ROOT / str(payload["compareRoot"]),
         ignore_globs=tuple(str(value) for value in payload.get("ignoreGlobs", [])),
@@ -184,7 +186,8 @@ def compare_against_upstream(config: UpstreamConfig, tag: str) -> CompareReport:
 
 
 def print_text_report(config: UpstreamConfig, report: CompareReport) -> None:
-    print(f"Tracked upstream tag: {config.tracked_tag}")
+    print(f"Original base tag: {config.original_base_tag}")
+    print(f"Tracked current-match tag: {config.tracked_tag}")
     print(f"Compared tag: {report.tag}")
     print(f"Modified upstream files: {len(report.modified_files)}")
     print(f"Missing upstream files: {len(report.missing_files)}")
@@ -226,6 +229,7 @@ def print_text_report(config: UpstreamConfig, report: CompareReport) -> None:
 
 def print_json_report(config: UpstreamConfig, report: CompareReport) -> None:
     payload = {
+        "originalBaseTag": config.original_base_tag,
         "trackedTag": config.tracked_tag,
         "comparedTag": report.tag,
         "modifiedFiles": list(report.modified_files),


### PR DESCRIPTION
## Summary
- record both the original darktable fork base (`release-5.4.0`) and the current matched upstream release (`release-5.4.1`)
- update the upstream status script, docs, and watcher workflow so sync metadata is accurate and less confusing
- keep the existing archive-based upstream verification flow unchanged while making provenance explicit