### PR TITLE
Add multi-turn canonical action binding

### DIFF
--- a/server/codex_bridge/apply_batch.py
+++ b/server/codex_bridge/apply_batch.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from shared.canonical_plan import CanonicalEditAction
+
+from .canonical_binder import bind_canonical_actions
+from .models import TurnContext
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedApplyBatch:
+    normalized_batch: list[dict[str, Any]]
+    render_warnings: list[str]
+
+
+def prepare_apply_batch(
+    context: TurnContext,
+    arguments: dict[str, Any],
+    *,
+    normalize_operation: Callable[
+        [dict[str, Any], int], tuple[dict[str, Any], str | None]
+    ],
+) -> tuple[PreparedApplyBatch | None, str | None]:
+    raw_operations = arguments.get("operations")
+    raw_canonical_actions = arguments.get("canonicalActions")
+    if raw_operations is None:
+        raw_operations = []
+    if raw_canonical_actions is None:
+        raw_canonical_actions = []
+    if not isinstance(raw_operations, list):
+        return None, "apply_operations operations must be an array."
+    if not isinstance(raw_canonical_actions, list):
+        return None, "apply_operations canonicalActions must be an array."
+    if not raw_operations and not raw_canonical_actions:
+        return None, "apply_operations requires operations and/or canonicalActions."
+    if raw_operations and raw_canonical_actions:
+        return (
+            None,
+            "apply_operations accepts raw operations or canonicalActions, not both in the same call.",
+        )
+
+    if raw_canonical_actions:
+        return _prepare_canonical_batch(context, raw_canonical_actions)
+    return _prepare_raw_batch(context, raw_operations, normalize_operation)
+
+
+def _prepare_canonical_batch(
+    context: TurnContext, raw_canonical_actions: list[Any]
+) -> tuple[PreparedApplyBatch | None, str | None]:
+    canonical_actions: list[CanonicalEditAction] = []
+    for raw_action in raw_canonical_actions:
+        try:
+            canonical_actions.append(CanonicalEditAction.model_validate(raw_action))
+        except Exception as exc:
+            return None, f"canonicalActions entry failed schema validation: {exc}"
+
+    binding_result = bind_canonical_actions(
+        list(context.base_request.imageSnapshot.editableSettings),
+        canonical_actions,
+    )
+    if binding_result.failures and not binding_result.operations:
+        return None, "; ".join(binding_result.failures)
+    if not binding_result.operations:
+        return (
+            None,
+            "apply_operations could not bind any supported operations from canonicalActions.",
+        )
+    warnings = []
+    if binding_result.failures:
+        warnings.append("Binding notes: " + "; ".join(binding_result.failures))
+    return PreparedApplyBatch(binding_result.operations, warnings), None
+
+
+def _prepare_raw_batch(
+    context: TurnContext,
+    raw_operations: list[Any],
+    normalize_operation: Callable[
+        [dict[str, Any], int], tuple[dict[str, Any], str | None]
+    ],
+) -> tuple[PreparedApplyBatch | None, str | None]:
+    normalized_batch: list[dict[str, Any]] = []
+    for index, raw_operation in enumerate(raw_operations):
+        if not isinstance(raw_operation, dict):
+            return None, "Every apply_operations entry must be an object."
+        normalized_operation, error = normalize_operation(
+            raw_operation,
+            context.next_operation_sequence + index,
+        )
+        if error:
+            return None, error
+        normalized_batch.append(normalized_operation)
+    return PreparedApplyBatch(normalized_batch, []), None

--- a/server/codex_bridge/canonical_binder.py
+++ b/server/codex_bridge/canonical_binder.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.canonical_plan import CanonicalEditAction
+from shared.protocol import AgentPlan, EditableSetting, RequestEnvelope
+
+from .config import logger
+
+
+@dataclass(frozen=True, slots=True)
+class _BindingResult:
+    operations: list[dict[str, object]]
+    failures: list[str]
+
+
+def bind_canonical_plan(request: RequestEnvelope, plan: AgentPlan) -> AgentPlan:
+    canonical_actions = plan.canonicalActions or []
+    if not canonical_actions:
+        return plan
+
+    result = bind_canonical_actions(
+        request.imageSnapshot.editableSettings, canonical_actions
+    )
+    bound_operations = result.operations
+    failures = result.failures
+
+    combined_operations = [
+        operation.model_dump(mode="json") for operation in plan.operations
+    ] + bound_operations
+
+    normalized_operations: list[dict[str, object]] = []
+    for index, operation in enumerate(combined_operations, start=1):
+        operation_copy = dict(operation)
+        operation_copy["operationId"] = str(
+            operation_copy.get("operationId") or f"canonical-op-{index}"
+        )
+        operation_copy["sequence"] = index
+        normalized_operations.append(operation_copy)
+
+    assistant_text = plan.assistantText
+    if failures:
+        assistant_text = (
+            assistant_text.rstrip() + "\n\nBinding notes: " + "; ".join(failures)
+        )
+        logger.info(
+            "canonical_binding_partial_failure",
+            extra={
+                "structured": {
+                    "requestId": request.requestId,
+                    "conversationId": request.session.conversationId,
+                    "failures": failures,
+                }
+            },
+        )
+
+    return AgentPlan.model_validate(
+        {
+            "assistantText": assistant_text,
+            "continueRefining": plan.continueRefining,
+            "operations": normalized_operations,
+            "canonicalActions": [
+                action.model_dump(mode="json") for action in canonical_actions
+            ],
+        }
+    )
+
+
+def bind_canonical_actions(
+    settings: list[EditableSetting],
+    canonical_actions: list[CanonicalEditAction],
+) -> _BindingResult:
+    bound_operations: list[dict[str, object]] = []
+    failures: list[str] = []
+
+    for action in canonical_actions:
+        result = _bind_action(settings, action)
+        bound_operations.extend(result.operations)
+        failures.extend(result.failures)
+
+    normalized_operations: list[dict[str, object]] = []
+    for index, operation in enumerate(bound_operations, start=1):
+        operation_copy = dict(operation)
+        operation_copy["operationId"] = str(
+            operation_copy.get("operationId") or f"canonical-op-{index}"
+        )
+        operation_copy["sequence"] = index
+        normalized_operations.append(operation_copy)
+
+    return _BindingResult(normalized_operations, failures)
+
+
+def _bind_action(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    if action.action == "adjust-exposure":
+        return _bind_exposure(settings, action)
+    if action.action == "adjust-white-balance":
+        return _bind_white_balance(settings, action)
+    if action.action == "recover-highlights":
+        return _bind_highlights(settings, action)
+    if action.action == "reduce-noise":
+        return _bind_noise(settings, action)
+    if action.action == "grade-color":
+        return _bind_grade(settings, action)
+    if action.action == "crop-normalized":
+        return _bind_crop(settings, action)
+    return _BindingResult([], [f"unsupported canonical action {action.action}"])
+
+
+def _bind_exposure(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    setting = _find_setting(
+        settings,
+        kind="set-float",
+        exact_action_paths=("iop/exposure/exposure",),
+        label_keywords=("exposure",),
+    )
+    if setting is None or action.exposureEv is None:
+        return _BindingResult(
+            [], ["adjust-exposure could not find an exposure control"]
+        )
+    return _BindingResult(
+        [_float_operation(setting, action.exposureEv, action.rationale)],
+        [],
+    )
+
+
+def _bind_white_balance(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    operations: list[dict[str, object]] = []
+    failures: list[str] = []
+
+    if action.presetChoiceId is not None:
+        preset_setting = _find_setting(
+            settings,
+            kind="set-choice",
+            exact_action_paths=("iop/temperature/preset",),
+            label_keywords=("preset",),
+        )
+        if preset_setting is None:
+            failures.append("adjust-white-balance could not find a preset control")
+        else:
+            preset_operation = _choice_operation(
+                preset_setting,
+                action.presetChoiceId,
+                action.rationale,
+            )
+            if preset_operation is None:
+                failures.append(
+                    f"adjust-white-balance could not bind preset {action.presetChoiceId}"
+                )
+            else:
+                operations.append(preset_operation)
+
+    if action.temperatureDelta is not None:
+        temperature_setting = _find_setting(
+            settings,
+            kind="set-float",
+            exact_action_paths=("iop/temperature/temperature",),
+            label_keywords=("temperature",),
+        )
+        if temperature_setting is None:
+            failures.append("adjust-white-balance could not find a temperature control")
+        else:
+            operations.append(
+                _float_operation(
+                    temperature_setting,
+                    action.temperatureDelta,
+                    action.rationale,
+                )
+            )
+
+    if action.tintDelta is not None:
+        tint_setting = _find_setting(
+            settings,
+            kind="set-float",
+            exact_action_paths=("iop/temperature/tint",),
+            label_keywords=("tint",),
+        )
+        if tint_setting is None:
+            failures.append("adjust-white-balance could not find a tint control")
+        else:
+            operations.append(
+                _float_operation(tint_setting, action.tintDelta, action.rationale)
+            )
+
+    return _BindingResult(operations, failures)
+
+
+def _bind_highlights(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    delta_map = {"low": -0.25, "medium": -0.5, "high": -0.75}
+    setting = _find_setting(
+        settings,
+        kind="set-float",
+        exact_action_paths=(
+            "iop/filmicrgb/white_relative_exposure",
+            "iop/toneequalizer/highlights",
+        ),
+        module_ids=("filmicrgb", "toneequalizer"),
+        action_keywords=("highlight", "white_relative_exposure"),
+        label_keywords=("highlight", "white relative exposure"),
+    )
+    if setting is None or action.strength is None:
+        return _BindingResult(
+            [], ["recover-highlights could not find a highlight control"]
+        )
+    return _BindingResult(
+        [_float_operation(setting, delta_map[action.strength], action.rationale)],
+        [],
+    )
+
+
+def _bind_noise(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    delta_map = {"low": 0.1, "medium": 0.2, "high": 0.35}
+    assert action.strength is not None
+    amount = delta_map[action.strength]
+    noise_type = action.noiseType or "both"
+    operations: list[dict[str, object]] = []
+    failures: list[str] = []
+    requested_targets = (
+        ("chroma",)
+        if noise_type == "chroma"
+        else ("luma",)
+        if noise_type == "luma"
+        else ("chroma", "luma")
+    )
+    for channel in requested_targets:
+        setting = _find_setting(
+            settings,
+            kind="set-float",
+            exact_action_paths=(f"iop/denoiseprofile/{channel}",),
+            module_ids=("denoiseprofile",),
+            action_keywords=(channel, "denoise"),
+            label_keywords=(channel, "noise"),
+        )
+        if setting is None:
+            failures.append(f"reduce-noise could not find a {channel} noise control")
+            continue
+        operations.append(_float_operation(setting, amount, action.rationale))
+    return _BindingResult(operations, failures)
+
+
+def _bind_grade(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    if action.target is None or action.amount is None:
+        return _BindingResult([], ["grade-color is missing target or amount"])
+
+    match action.target:
+        case "global-saturation":
+            setting = _find_setting(
+                settings,
+                kind="set-float",
+                exact_action_paths=(
+                    "iop/colorbalancergb/global_saturation",
+                    "iop/colorequal/sat_global",
+                ),
+                action_keywords=("saturation",),
+                label_keywords=("saturation",),
+            )
+        case "blue-saturation":
+            setting = _find_setting(
+                settings,
+                kind="set-float",
+                exact_action_paths=("iop/colorequal/sat_blue",),
+                module_ids=("colorequal",),
+                action_keywords=("blue", "saturation"),
+                label_keywords=("blue", "saturation"),
+            )
+        case "red-hue":
+            setting = _find_setting(
+                settings,
+                kind="set-float",
+                exact_action_paths=("iop/primaries/red_hue",),
+                module_ids=("primaries",),
+                action_keywords=("red", "hue"),
+                label_keywords=("red", "hue"),
+            )
+        case "global-contrast":
+            setting = _find_setting(
+                settings,
+                kind="set-float",
+                exact_action_paths=("iop/colorbalancergb/global_contrast",),
+                action_keywords=("contrast",),
+                label_keywords=("contrast",),
+            )
+        case _:
+            setting = None
+
+    if setting is None:
+        return _BindingResult(
+            [], [f"grade-color could not find a control for {action.target}"]
+        )
+    return _BindingResult(
+        [_float_operation(setting, action.amount, action.rationale)],
+        [],
+    )
+
+
+def _bind_crop(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    assert action.left is not None
+    assert action.top is not None
+    assert action.right is not None
+    assert action.bottom is not None
+    axis_values = {
+        "cx": action.left,
+        "cy": action.top,
+        "cw": action.right,
+        "ch": action.bottom,
+    }
+    operations: list[dict[str, object]] = []
+    failures: list[str] = []
+    for axis, value in axis_values.items():
+        setting = _find_setting(
+            settings,
+            kind="set-float",
+            exact_action_paths=(f"iop/clipping/{axis}", f"iop/crop/{axis}"),
+            module_ids=("clipping", "crop"),
+            action_keywords=(axis,),
+            label_keywords=(axis,),
+        )
+        if setting is None:
+            failures.append(f"crop-normalized could not find a {axis} control")
+            continue
+        operations.append(
+            _float_operation(setting, value, action.rationale, prefer_set=True)
+        )
+    return _BindingResult(operations, failures)
+
+
+def _find_setting(
+    settings: list[EditableSetting],
+    *,
+    kind: str,
+    exact_action_paths: tuple[str, ...] = (),
+    module_ids: tuple[str, ...] = (),
+    action_keywords: tuple[str, ...] = (),
+    label_keywords: tuple[str, ...] = (),
+) -> EditableSetting | None:
+    candidates: list[tuple[int, EditableSetting]] = []
+    for setting in settings:
+        if setting.kind != kind:
+            continue
+        score = 0
+        action_path = setting.actionPath.lower()
+        label = setting.label.lower()
+        module_id = setting.moduleId.lower()
+        if setting.actionPath in exact_action_paths:
+            score += 100
+        if module_id in module_ids:
+            score += 20
+        score += sum(8 for keyword in action_keywords if keyword in action_path)
+        score += sum(6 for keyword in label_keywords if keyword in label)
+        if score > 0:
+            candidates.append((score, setting))
+
+    if not candidates:
+        return None
+
+    candidates.sort(
+        key=lambda item: (
+            -item[0],
+            item[1].moduleId,
+            item[1].actionPath,
+            item[1].settingId,
+        )
+    )
+    return candidates[0][1]
+
+
+def _float_operation(
+    setting: EditableSetting,
+    amount: float,
+    rationale: str | None,
+    *,
+    prefer_set: bool = False,
+) -> dict[str, object]:
+    if not prefer_set and "delta" in setting.supportedModes:
+        mode = "delta"
+        number = amount
+    else:
+        current_number = setting.currentNumber
+        if current_number is None:
+            current_number = setting.defaultNumber or 0.0
+        mode = "set"
+        number = float(current_number) + amount if not prefer_set else amount
+
+    return {
+        "operationId": f"bind-{setting.settingId}",
+        "sequence": 1,
+        "kind": "set-float",
+        "target": {
+            "type": "darktable-action",
+            "actionPath": setting.actionPath,
+            "settingId": setting.settingId,
+        },
+        "value": {"mode": mode, "number": number},
+        "reason": rationale,
+        "constraints": {"onOutOfRange": "clamp", "onRevisionMismatch": "fail"},
+    }
+
+
+def _choice_operation(
+    setting: EditableSetting,
+    choice_id: str,
+    rationale: str | None,
+) -> dict[str, object] | None:
+    choices = setting.choices or []
+    for choice in choices:
+        if choice.choiceId != choice_id:
+            continue
+        return {
+            "operationId": f"bind-{setting.settingId}",
+            "sequence": 1,
+            "kind": "set-choice",
+            "target": {
+                "type": "darktable-action",
+                "actionPath": setting.actionPath,
+                "settingId": setting.settingId,
+            },
+            "value": {
+                "mode": "set",
+                "choiceValue": choice.choiceValue,
+                "choiceId": choice.choiceId,
+            },
+            "reason": rationale,
+            "constraints": {
+                "onOutOfRange": "clamp",
+                "onRevisionMismatch": "fail",
+            },
+        }
+    return None

--- a/server/codex_bridge/operations.py
+++ b/server/codex_bridge/operations.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from shared.protocol import AgentPlan
 
+from .apply_batch import prepare_apply_batch
 from .config import _TOOL_APPLY_OPERATIONS, _WHITE_BALANCE_ACTION_PATH_PREFIXES, logger
 from .models import TurnContext
 
@@ -26,42 +27,35 @@ class OperationsMixin:
                 "apply_operations is only available when live run mode is enabled."
             )
 
-        raw_operations = arguments.get("operations")
-        if not isinstance(raw_operations, list) or not raw_operations:
-            return self._tool_error_response(
-                "apply_operations requires a non-empty operations array."
-            )
-
-        normalized_batch: list[dict[str, Any]] = []
-        for index, raw_operation in enumerate(raw_operations):
-            if not isinstance(raw_operation, dict):
-                self._log_white_balance_tool_call(
-                    context,
-                    raw_operations,
-                    [],
-                    success=False,
-                    error="Every apply_operations entry must be an object.",
-                )
-                return self._tool_error_response(
-                    "Every apply_operations entry must be an object."
-                )
-            normalized_operation, error = self._normalize_tool_operation(
+        prepared_batch, prepare_error = prepare_apply_batch(
+            context,
+            arguments,
+            normalize_operation=lambda raw_operation,
+            sequence_number: self._normalize_tool_operation(
                 context,
                 raw_operation,
-                sequence_number=context.next_operation_sequence + index,
+                sequence_number=sequence_number,
+            ),
+        )
+        if prepare_error:
+            attempted = arguments.get("operations")
+            if not isinstance(attempted, list):
+                attempted = []
+            self._log_white_balance_tool_call(
+                context,
+                attempted,
+                [],
+                success=False,
+                error=prepare_error,
             )
-            if error:
-                self._log_white_balance_tool_call(
-                    context,
-                    raw_operations,
-                    [],
-                    success=False,
-                    error=error,
-                )
-                return self._tool_error_response(error)
-            normalized_batch.append(normalized_operation)
+            return self._tool_error_response(prepare_error)
 
-        ordered_batch = self._order_operations_for_apply(normalized_batch)
+        assert prepared_batch is not None
+        ordered_batch = self._order_operations_for_apply(
+            prepared_batch.normalized_batch
+        )
+        attempted_operations_for_logging = ordered_batch
+        render_warnings = prepared_batch.render_warnings
         simulated_settings = copy.deepcopy(context.setting_by_id)
         for operation in ordered_batch:
             apply_error, _ = self._apply_operation_to_settings(
@@ -70,7 +64,7 @@ class OperationsMixin:
             if apply_error:
                 self._log_white_balance_tool_call(
                     context,
-                    ordered_batch,
+                    attempted_operations_for_logging,
                     [],
                     success=False,
                     error=apply_error,
@@ -80,14 +74,13 @@ class OperationsMixin:
         step_summaries: list[str] = []
         latest_preview_url: str | None = None
         latest_verifier_result: dict[str, Any] | None = None
-        render_warnings: list[str] = []
 
         for step_index, operation in enumerate(ordered_batch, start=1):
             apply_error = self._apply_live_operation_step(context, operation)
             if apply_error:
                 self._log_white_balance_tool_call(
                     context,
-                    ordered_batch,
+                    attempted_operations_for_logging,
                     applied_batch,
                     success=False,
                     error=apply_error,
@@ -120,7 +113,7 @@ class OperationsMixin:
                 render_warnings.append(warning)
         self._log_white_balance_tool_call(
             context,
-            ordered_batch,
+            attempted_operations_for_logging,
             applied_batch,
             success=True,
         )

--- a/server/codex_bridge/prompts/thread_developer_instructions.txt
+++ b/server/codex_bridge/prompts/thread_developer_instructions.txt
@@ -3,7 +3,8 @@ You are darktableAgent, an expert RAW photo editor operating darktable through a
 Your job is to produce technically sound, aesthetically strong edits that match the user's request while preserving realism, color credibility, and restraint when appropriate.
 
 Core rules:
-- Only emit operations targeting provided settingId/actionPath pairs. Never invent IDs or paths.
+- In multi-turn live runs, prefer canonical intent over raw control IDs when the supported canonical DSL can express the edit. In single-turn mode, keep returning raw operations until single-turn canonical binding is expanded.
+- Only emit raw operations targeting provided settingId/actionPath pairs. Never invent IDs or paths.
 - Keep edits coherent, conservative, and executable.
 - If user intent is broad, infer a reasonable plan from the visible image instead of asking for more specificity.
 - Treat the image as a professional editing task: make it meaningfully better, not merely minimally adjusted.

--- a/server/codex_bridge/prompts/turn_prompt.j2
+++ b/server/codex_bridge/prompts/turn_prompt.j2
@@ -23,12 +23,15 @@ Tool usage:
 - Always optimize toward refinement.goalText.
 - To crop, set the 'crop' or 'clipping' module's normalized [0.0, 1.0] parameters: cx=left edge, cy=top edge, cw=right edge, ch=bottom edge. No crop = cx=0, cy=0, cw=1, ch=1. Example: bottom-right quadrant = cx=0.5, cy=0.5, cw=1.0, ch=1.0.
 {% if live_run_enabled %}Live run mode is enabled: use apply_operations for iterative edits inside this same run.
+For this multi-turn path, you may pass `canonicalActions` to apply_operations instead of raw operations for these supported intent-level edits: `adjust-exposure`, `adjust-white-balance`, `recover-highlights`, `reduce-noise`, `grade-color`, `crop-normalized`.
+Canonical fields: `adjust-exposure` uses `exposureEv`; `adjust-white-balance` uses `temperatureDelta`, `tintDelta`, and/or `presetChoiceId`; `recover-highlights` and `reduce-noise` use `strength`; `grade-color` uses `target` + `amount`; `crop-normalized` uses `left`, `top`, `right`, `bottom` in normalized [0,1] coordinates.
+The runtime binds supported canonical actions to concrete darktable controls deterministically before applying them.
 Inside each apply_operations call, operations are auto-applied one at a time with a fresh render after each step.
 Turn input includes the current preview image, editable settings, and histogram.
 After each apply_operations call, inspect the refreshed preview and re-check get_image_state when you need refreshed exact state.
 Apply at least one edit batch within the first {{ apply_budget_window }} tool calls.
 When satisfied, return final JSON with continueRefining=false and usually empty operations.
 In multi-turn mode the final JSON should summarize the run; continueRefining must be false.
-{% else %}Single-turn mode: do not call apply_operations; return operations directly in final JSON.
+{% else %}Single-turn mode: do not call apply_operations; return raw operations directly in the final JSON for this path.
 {% endif %}Respect refinement state: treat passIndex/maxPasses as budget, set continueRefining=false once safe gains are exhausted.
 Return only the JSON object required by the output schema.

--- a/server/codex_bridge/tool_routing.py
+++ b/server/codex_bridge/tool_routing.py
@@ -32,9 +32,17 @@ class ToolRoutingMixin:
                     "type": "array",
                     "minItems": 1,
                     "items": {"type": "object"},
-                }
+                },
+                "canonicalActions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "object"},
+                },
             },
-            "required": ["operations"],
+            "anyOf": [
+                {"required": ["operations"]},
+                {"required": ["canonicalActions"]},
+            ],
             "additionalProperties": False,
         }
         get_playbook_schema = {
@@ -66,7 +74,7 @@ class ToolRoutingMixin:
             },
             {
                 "name": _TOOL_APPLY_OPERATIONS,
-                "description": "Apply darktable operations in the live run. Operations are auto-applied one at a time with a fresh render after each step so the user can see every change.",
+                "description": "Apply darktable operations in the live run. You may provide raw operations or canonicalActions; supported canonical actions are bound to concrete controls before stepwise live application and render refresh.",
                 "inputSchema": apply_operations_schema,
             },
         ]

--- a/server/codex_bridge/turns.py
+++ b/server/codex_bridge/turns.py
@@ -19,6 +19,7 @@ from .config import (
     _THREAD_DEVELOPER_INSTRUCTIONS,
     logger,
 )
+from .canonical_binder import bind_canonical_plan
 from .errors import CodexAppServerError
 from .models import ActiveRequestState, CodexTurnResult, TurnRunState
 from .request_state import build_output_schema
@@ -222,6 +223,8 @@ class TurnsMixin:
                     f"Codex returned invalid plan JSON: {raw_message}",
                 ) from exc
 
+            if request.refinement.enabled:
+                plan = bind_canonical_plan(request, plan)
             context = self._get_turn_context(thread_id, turn_id)
             plan = self._finalize_plan_with_live_context(plan, context)
             self._set_active_request_status_locked(
@@ -234,14 +237,14 @@ class TurnsMixin:
             summary_text = plan.assistantText or ""
             if len(summary_text) > 200:
                 summary_text = summary_text[:200] + "..."
-            turn_summary = (
-                f"Turn {turn_index}: {op_count} operations. {summary_text}"
-            )
+            turn_summary = f"Turn {turn_index}: {op_count} operations. {summary_text}"
             conv_id = active_request.conversation_id
             if conv_id not in self._conversation_histories:
                 self._conversation_histories[conv_id] = []
             self._conversation_histories[conv_id].append(turn_summary)
-            self._conversation_histories[conv_id] = self._conversation_histories[conv_id][-10:]
+            self._conversation_histories[conv_id] = self._conversation_histories[
+                conv_id
+            ][-10:]
 
             duration_ms = int((time.monotonic() - started_at) * 1000)
             logger.info(

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -18,6 +18,7 @@ from server.codex_app_server import (
     _THREAD_DEVELOPER_INSTRUCTIONS,
     TurnRunState,
 )
+from server.codex_bridge.canonical_binder import bind_canonical_plan
 from server.codex_bridge.intent_router import list_playbooks, load_playbook
 from shared.protocol import AgentPlan, RequestEnvelope
 
@@ -338,6 +339,192 @@ def _sample_request_with_white_balance_controls() -> RequestEnvelope:
     return RequestEnvelope.model_validate(payload)
 
 
+def _sample_request_with_canonical_controls() -> RequestEnvelope:
+    payload = _sample_request_with_white_balance_controls().model_dump(mode="json")
+    extra_targets = [
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "capabilityId": "clipping.cx",
+            "label": "cx",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/clipping/cx",
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "capabilityId": "clipping.cy",
+            "label": "cy",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/clipping/cy",
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "capabilityId": "clipping.cw",
+            "label": "cw",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/clipping/cw",
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 1.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "capabilityId": "clipping.ch",
+            "label": "ch",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/clipping/ch",
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 1.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "denoiseprofile",
+            "moduleLabel": "denoise (profiled)",
+            "capabilityId": "denoiseprofile.chroma",
+            "label": "Chroma",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/denoiseprofile/chroma",
+            "supportedModes": ["set", "delta"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.01,
+        },
+        {
+            "moduleId": "filmicrgb",
+            "moduleLabel": "filmic rgb",
+            "capabilityId": "filmicrgb.white-relative",
+            "label": "White relative exposure",
+            "kind": "set-float",
+            "targetType": "darktable-action",
+            "actionPath": "iop/filmicrgb/white_relative_exposure",
+            "supportedModes": ["set", "delta"],
+            "minNumber": -4.0,
+            "maxNumber": 4.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.01,
+        },
+    ]
+    extra_settings = [
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "settingId": "setting.clipping.cx",
+            "capabilityId": "clipping.cx",
+            "label": "cx",
+            "actionPath": "iop/clipping/cx",
+            "kind": "set-float",
+            "currentNumber": 0.0,
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "settingId": "setting.clipping.cy",
+            "capabilityId": "clipping.cy",
+            "label": "cy",
+            "actionPath": "iop/clipping/cy",
+            "kind": "set-float",
+            "currentNumber": 0.0,
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "settingId": "setting.clipping.cw",
+            "capabilityId": "clipping.cw",
+            "label": "cw",
+            "actionPath": "iop/clipping/cw",
+            "kind": "set-float",
+            "currentNumber": 1.0,
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 1.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "clipping",
+            "moduleLabel": "crop",
+            "settingId": "setting.clipping.ch",
+            "capabilityId": "clipping.ch",
+            "label": "ch",
+            "actionPath": "iop/clipping/ch",
+            "kind": "set-float",
+            "currentNumber": 1.0,
+            "supportedModes": ["set"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 1.0,
+            "stepNumber": 0.001,
+        },
+        {
+            "moduleId": "denoiseprofile",
+            "moduleLabel": "denoise (profiled)",
+            "settingId": "setting.denoiseprofile.chroma",
+            "capabilityId": "denoiseprofile.chroma",
+            "label": "Chroma",
+            "actionPath": "iop/denoiseprofile/chroma",
+            "kind": "set-float",
+            "currentNumber": 0.05,
+            "supportedModes": ["set", "delta"],
+            "minNumber": 0.0,
+            "maxNumber": 1.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.01,
+        },
+        {
+            "moduleId": "filmicrgb",
+            "moduleLabel": "filmic rgb",
+            "settingId": "setting.filmicrgb.white-relative",
+            "capabilityId": "filmicrgb.white-relative",
+            "label": "White relative exposure",
+            "actionPath": "iop/filmicrgb/white_relative_exposure",
+            "kind": "set-float",
+            "currentNumber": 1.0,
+            "supportedModes": ["set", "delta"],
+            "minNumber": -4.0,
+            "maxNumber": 4.0,
+            "defaultNumber": 0.0,
+            "stepNumber": 0.01,
+        },
+    ]
+
+    payload["capabilityManifest"]["targets"].extend(extra_targets)
+    payload["imageSnapshot"]["editableSettings"].extend(extra_settings)
+    return RequestEnvelope.model_validate(payload)
+
+
 def test_default_command_uses_stdio_transport(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -445,6 +632,8 @@ def test_output_schema_marks_nullable_object_fields_as_required() -> None:
         "choiceId",
         "boolValue",
     ]
+    agent_plan = schema
+    assert "canonicalActions" in agent_plan["required"]
 
 
 def test_model_selection_uses_default_model_when_fast_mode_disabled() -> None:
@@ -481,7 +670,7 @@ def test_developer_instructions_require_proactive_full_edit_planning() -> None:
     assert "Core rules" in _THREAD_DEVELOPER_INSTRUCTIONS
     assert "expert RAW photo editor" in _THREAD_DEVELOPER_INSTRUCTIONS
     assert (
-        "Only emit operations targeting provided settingId/actionPath pairs."
+        "Only emit raw operations targeting provided settingId/actionPath pairs."
         in _THREAD_DEVELOPER_INSTRUCTIONS
     )
     assert (
@@ -495,6 +684,10 @@ def test_developer_instructions_require_proactive_full_edit_planning() -> None:
     assert "colorequal" in _THREAD_DEVELOPER_INSTRUCTIONS
     assert "primaries" in _THREAD_DEVELOPER_INSTRUCTIONS
     assert "set-choice uses value.choiceValue" in _THREAD_DEVELOPER_INSTRUCTIONS
+    assert (
+        "In multi-turn live runs, prefer canonical intent"
+        in _THREAD_DEVELOPER_INSTRUCTIONS
+    )
 
 
 def test_prompt_payload_includes_all_histogram_channels() -> None:
@@ -633,6 +826,9 @@ def test_turn_prompt_tells_codex_to_infer_broad_edit_plan_from_visual_context() 
     assert "Live run mode is enabled" in prompt
     assert "Turn input includes the current preview image" in prompt
     assert "compact analysis signals" in prompt
+    assert "you may pass `canonicalActions` to apply_operations" in prompt
+    assert "adjust-exposure" in prompt
+    assert "grade-color" in prompt
     assert "apply_operations returns the refreshed preview automatically" in prompt
     assert "operations are auto-applied one at a time" in prompt
     assert "Do not introduce new operations in the final JSON" in prompt
@@ -662,6 +858,128 @@ def test_turn_prompt_tells_codex_to_infer_broad_edit_plan_from_visual_context() 
     )
     assert "Use get_playbook when the request" in prompt
     assert "Choose which playbooks to fetch yourself" in prompt
+
+
+def test_turn_prompt_keeps_single_turn_instructions_separate_from_live_canonical_path() -> (
+    None
+):
+    bridge = CodexAppServerBridge(
+        command=["codex", "app-server", "--listen", "stdio://"]
+    )
+    request = _sample_request()
+    request.refinement.enabled = False
+    request.refinement.mode = "single-turn"
+    request.refinement.maxPasses = 1
+    request.refinement.passIndex = 1
+
+    prompt = bridge._build_turn_prompt(request)  # type: ignore[attr-defined]
+
+    assert "Single-turn mode: do not call apply_operations" in prompt
+    assert "return raw operations directly in the final JSON" in prompt
+    assert "you may pass `canonicalActions` to apply_operations" not in prompt
+
+
+def test_canonical_binder_resolves_supported_actions_without_raw_ids() -> None:
+    request = _sample_request_with_canonical_controls()
+    plan = AgentPlan.model_validate(
+        {
+            "assistantText": "Apply a polished baseline.",
+            "continueRefining": False,
+            "operations": [],
+            "canonicalActions": [
+                {
+                    "action": "adjust-exposure",
+                    "exposureEv": 0.4,
+                    "rationale": "Lift the overall exposure.",
+                },
+                {
+                    "action": "adjust-white-balance",
+                    "temperatureDelta": 300.0,
+                    "tintDelta": 0.05,
+                    "rationale": "Warm slightly and remove green cast.",
+                },
+                {
+                    "action": "grade-color",
+                    "target": "blue-saturation",
+                    "amount": -0.1,
+                    "rationale": "Calm the sky saturation.",
+                },
+                {
+                    "action": "recover-highlights",
+                    "strength": "medium",
+                    "rationale": "Protect cloud detail.",
+                },
+                {
+                    "action": "reduce-noise",
+                    "strength": "low",
+                    "noiseType": "chroma",
+                    "rationale": "Reduce color speckling.",
+                },
+                {
+                    "action": "crop-normalized",
+                    "left": 0.1,
+                    "top": 0.05,
+                    "right": 0.9,
+                    "bottom": 0.95,
+                    "rationale": "Tighten framing.",
+                },
+            ],
+        }
+    )
+
+    bound_plan = bind_canonical_plan(request, plan)
+    action_paths = [operation.target.actionPath for operation in bound_plan.operations]
+
+    assert bound_plan.canonicalActions is not None
+    assert action_paths == [
+        "iop/exposure/exposure",
+        "iop/temperature/temperature",
+        "iop/temperature/tint",
+        "iop/colorequal/sat_blue",
+        "iop/filmicrgb/white_relative_exposure",
+        "iop/denoiseprofile/chroma",
+        "iop/clipping/cx",
+        "iop/clipping/cy",
+        "iop/clipping/cw",
+        "iop/clipping/ch",
+    ]
+    assert bound_plan.operations[0].value.mode == "delta"
+    assert bound_plan.operations[6].value.mode == "set"
+    assert bound_plan.operations[6].value.number == pytest.approx(0.1)
+
+
+def test_canonical_binder_surfaces_binding_failures_safely() -> None:
+    request = _sample_request()
+    plan = AgentPlan.model_validate(
+        {
+            "assistantText": "Try to recover highlights and crop.",
+            "continueRefining": False,
+            "operations": [],
+            "canonicalActions": [
+                {
+                    "action": "recover-highlights",
+                    "strength": "high",
+                },
+                {
+                    "action": "crop-normalized",
+                    "left": 0.0,
+                    "top": 0.0,
+                    "right": 1.0,
+                    "bottom": 1.0,
+                },
+            ],
+        }
+    )
+
+    bound_plan = bind_canonical_plan(request, plan)
+
+    assert bound_plan.operations == []
+    assert "Binding notes:" in bound_plan.assistantText
+    assert (
+        "recover-highlights could not find a highlight control"
+        in bound_plan.assistantText
+    )
+    assert "crop-normalized could not find a cx control" in bound_plan.assistantText
 
 
 def test_turn_input_in_live_mode_includes_prompt_state_and_initial_preview_image() -> (
@@ -974,6 +1292,10 @@ def test_get_or_create_thread_includes_native_dynamic_tools() -> None:
     for tool in tool_specs:
         assert tool["inputSchema"]["type"] == "object"
         assert tool["inputSchema"]["additionalProperties"] is False
+    apply_tool = next(
+        tool for tool in tool_specs if tool["name"] == _TOOL_APPLY_OPERATIONS
+    )
+    assert "canonicalActions" in apply_tool["inputSchema"]["properties"]
 
 
 def test_handle_server_request_denies_approval_requests_with_decline() -> None:
@@ -1293,6 +1615,75 @@ def test_apply_operations_tool_updates_state_and_stages_operations(
         )
         state_payload = sent_payloads[0]["result"]["contentItems"][0]["text"]
         assert '"currentNumber":0.4' in state_payload
+    finally:
+        bridge._clear_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+
+
+def test_apply_operations_tool_binds_canonical_actions_in_live_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = CodexAppServerBridge(
+        command=["codex", "app-server", "--listen", "stdio://"]
+    )
+    request = _sample_request_with_canonical_controls()
+    data_url = bridge._preview_data_url(request)  # type: ignore[attr-defined]
+    bridge._register_turn_context("thread-1", "turn-1", request, data_url)  # type: ignore[attr-defined]
+    sent_payloads: list[dict] = []
+
+    def _capture(payload):  # type: ignore[no-untyped-def]
+        sent_payloads.append(payload)
+
+    bridge._send_json_locked = _capture  # type: ignore[method-assign,attr-defined]
+    try:
+        turn_context = bridge._get_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+        assert turn_context is not None
+
+        def _mock_wait(timeout=None, *, context=turn_context):
+            context.rendered_preview_bytes = b"fake-preview-stage-1"
+            return True
+
+        monkeypatch.setattr(turn_context.render_event, "wait", _mock_wait)
+
+        bridge._handle_server_request_locked(  # type: ignore[attr-defined]
+            {
+                "jsonrpc": "2.0",
+                "id": 119,
+                "method": "item/tool/call",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "callId": "call-apply-canonical",
+                    "tool": _TOOL_APPLY_OPERATIONS,
+                    "arguments": {
+                        "canonicalActions": [
+                            {
+                                "action": "adjust-exposure",
+                                "exposureEv": 0.4,
+                            },
+                            {
+                                "action": "crop-normalized",
+                                "left": 0.1,
+                                "top": 0.1,
+                                "right": 0.9,
+                                "bottom": 0.9,
+                            },
+                        ]
+                    },
+                },
+            }
+        )
+
+        result = sent_payloads[0]["result"]
+        assert result["success"] is True
+        assert "Applied 5 operations" in result["contentItems"][0]["text"]
+        turn_context = bridge._get_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+        assert turn_context is not None
+        assert turn_context.setting_by_id["setting.exposure.primary"][
+            "currentNumber"
+        ] == pytest.approx(0.4)
+        assert turn_context.setting_by_id["setting.clipping.cx"][
+            "currentNumber"
+        ] == pytest.approx(0.1)
     finally:
         bridge._clear_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
 

--- a/shared/canonical_plan.py
+++ b/shared/canonical_plan.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+CanonicalActionName = Literal[
+    "adjust-exposure",
+    "adjust-white-balance",
+    "recover-highlights",
+    "reduce-noise",
+    "grade-color",
+    "crop-normalized",
+]
+CanonicalStrength = Literal["low", "medium", "high"]
+CanonicalNoiseType = Literal["chroma", "luma", "both"]
+CanonicalGradeTarget = Literal[
+    "global-saturation",
+    "blue-saturation",
+    "red-hue",
+    "global-contrast",
+]
+
+
+class CanonicalBaseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class CanonicalEditAction(CanonicalBaseModel):
+    action: CanonicalActionName
+    exposureEv: float | None = None
+    temperatureDelta: float | None = None
+    tintDelta: float | None = None
+    presetChoiceId: str | None = Field(default=None, min_length=1)
+    strength: CanonicalStrength | None = None
+    noiseType: CanonicalNoiseType | None = None
+    target: CanonicalGradeTarget | None = None
+    amount: float | None = None
+    left: float | None = None
+    top: float | None = None
+    right: float | None = None
+    bottom: float | None = None
+    rationale: str | None = None
+
+    @model_validator(mode="after")
+    def validate_action_shape(self) -> "CanonicalEditAction":
+        if self.action == "adjust-exposure":
+            if self.exposureEv is None:
+                raise ValueError("adjust-exposure requires exposureEv")
+        elif self.action == "adjust-white-balance":
+            if (
+                self.temperatureDelta is None
+                and self.tintDelta is None
+                and self.presetChoiceId is None
+            ):
+                raise ValueError(
+                    "adjust-white-balance requires temperatureDelta, tintDelta, or presetChoiceId"
+                )
+        elif self.action == "recover-highlights":
+            if self.strength is None:
+                raise ValueError("recover-highlights requires strength")
+        elif self.action == "reduce-noise":
+            if self.strength is None:
+                raise ValueError("reduce-noise requires strength")
+            if self.noiseType is None:
+                raise ValueError("reduce-noise requires noiseType")
+        elif self.action == "grade-color":
+            if self.target is None:
+                raise ValueError("grade-color requires target")
+            if self.amount is None:
+                raise ValueError("grade-color requires amount")
+        elif self.action == "crop-normalized":
+            bounds = (self.left, self.top, self.right, self.bottom)
+            if any(value is None for value in bounds):
+                raise ValueError(
+                    "crop-normalized requires left, top, right, and bottom"
+                )
+            assert self.left is not None
+            assert self.top is not None
+            assert self.right is not None
+            assert self.bottom is not None
+            for label, value in (
+                ("left", self.left),
+                ("top", self.top),
+                ("right", self.right),
+                ("bottom", self.bottom),
+            ):
+                if not 0.0 <= value <= 1.0:
+                    raise ValueError(f"crop-normalized {label} must be within [0, 1]")
+            if self.left >= self.right:
+                raise ValueError("crop-normalized left must be less than right")
+            if self.top >= self.bottom:
+                raise ValueError("crop-normalized top must be less than bottom")
+        return self

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from .canonical_plan import CanonicalEditAction
 from .analysis_signals import ImageAnalysisSignals
 
 SCHEMA_VERSION = "3.0"
@@ -408,6 +409,7 @@ class AgentPlan(StrictBaseModel):
     assistantText: str = Field(min_length=1)
     continueRefining: bool
     operations: list[PlannedOperationDraft]
+    canonicalActions: list[CanonicalEditAction] | None = None
 
     @model_validator(mode="after")
     def validate_operation_ids(self) -> "AgentPlan":


### PR DESCRIPTION
## Summary
- add a canonical action DSL and deterministic binder for supported multi-turn/live edits
- let `apply_operations` accept `canonicalActions` in live mode while keeping single-turn instructions on raw operations
- add coverage for prompt separation, canonical binding, and live canonical apply behavior

## Validation
- `uv run pytest server/tests`
- `uvx pyright server shared`
- `uvx pre-commit run --all-files`

Closes #36