### PR TITLE
Translate bounding-box crops into crop controls

### DIFF
--- a/server/codex_bridge/canonical_binder.py
+++ b/server/codex_bridge/canonical_binder.py
@@ -105,6 +105,8 @@ def _bind_action(
         return _bind_grade(settings, action)
     if action.action == "crop-normalized":
         return _bind_crop(settings, action)
+    if action.action == "crop-to-bounding-box":
+        return _bind_crop_box(settings, action)
     return _BindingResult([], [f"unsupported canonical action {action.action}"])
 
 
@@ -317,6 +319,51 @@ def _bind_crop(
         "cw": action.right,
         "ch": action.bottom,
     }
+    return _bind_crop_axis_values(
+        settings,
+        axis_values,
+        rationale=action.rationale,
+        failure_prefix="crop-normalized",
+    )
+
+
+def _bind_crop_box(
+    settings: list[EditableSetting], action: CanonicalEditAction
+) -> _BindingResult:
+    assert action.boxLeft is not None
+    assert action.boxTop is not None
+    assert action.boxWidth is not None
+    assert action.boxHeight is not None
+    padding_ratio = action.paddingRatio or 0.0
+
+    left = _clamp(action.boxLeft)
+    top = _clamp(action.boxTop)
+    right = _clamp(action.boxLeft + action.boxWidth)
+    bottom = _clamp(action.boxTop + action.boxHeight)
+    pad_x = action.boxWidth * padding_ratio
+    pad_y = action.boxHeight * padding_ratio
+
+    axis_values = {
+        "cx": _clamp(left - pad_x),
+        "cy": _clamp(top - pad_y),
+        "cw": _clamp(right + pad_x),
+        "ch": _clamp(bottom + pad_y),
+    }
+    return _bind_crop_axis_values(
+        settings,
+        axis_values,
+        rationale=action.rationale,
+        failure_prefix="crop-to-bounding-box",
+    )
+
+
+def _bind_crop_axis_values(
+    settings: list[EditableSetting],
+    axis_values: dict[str, float],
+    *,
+    rationale: str | None,
+    failure_prefix: str,
+) -> _BindingResult:
     operations: list[dict[str, object]] = []
     failures: list[str] = []
     for axis, value in axis_values.items():
@@ -329,12 +376,14 @@ def _bind_crop(
             label_keywords=(axis,),
         )
         if setting is None:
-            failures.append(f"crop-normalized could not find a {axis} control")
+            failures.append(f"{failure_prefix} could not find a {axis} control")
             continue
-        operations.append(
-            _float_operation(setting, value, action.rationale, prefer_set=True)
-        )
+        operations.append(_float_operation(setting, value, rationale, prefer_set=True))
     return _BindingResult(operations, failures)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
 
 
 def _find_setting(

--- a/server/codex_bridge/prompts/turn_prompt.j2
+++ b/server/codex_bridge/prompts/turn_prompt.j2
@@ -21,10 +21,10 @@ Tool usage:
 - In live mode, every actual edit must be performed through apply_operations. Do not introduce new operations in the final JSON that were not already applied successfully.
 - Before finalizing, consider whether additional provided controls would materially improve tone, color, detail, crop, or noise; do not stop at basic exposure/contrast edits when stronger supported tools are available.
 - Always optimize toward refinement.goalText.
-- To crop, set the 'crop' or 'clipping' module's normalized [0.0, 1.0] parameters: cx=left edge, cy=top edge, cw=right edge, ch=bottom edge. No crop = cx=0, cy=0, cw=1, ch=1. Example: bottom-right quadrant = cx=0.5, cy=0.5, cw=1.0, ch=1.0.
 {% if live_run_enabled %}Live run mode is enabled: use apply_operations for iterative edits inside this same run.
-For this multi-turn path, you may pass `canonicalActions` to apply_operations instead of raw operations for these supported intent-level edits: `adjust-exposure`, `adjust-white-balance`, `recover-highlights`, `reduce-noise`, `grade-color`, `crop-normalized`.
+For this multi-turn path, you may pass `canonicalActions` to apply_operations instead of raw operations for these supported intent-level edits: `adjust-exposure`, `adjust-white-balance`, `recover-highlights`, `reduce-noise`, `grade-color`, `crop-normalized`, `crop-to-bounding-box`.
 Canonical fields: `adjust-exposure` uses `exposureEv`; `adjust-white-balance` uses `temperatureDelta`, `tintDelta`, and/or `presetChoiceId`; `recover-highlights` and `reduce-noise` use `strength`; `grade-color` uses `target` + `amount`; `crop-normalized` uses `left`, `top`, `right`, `bottom` in normalized [0,1] coordinates.
+For subject-centric crops, prefer `crop-to-bounding-box` over raw crop edges: provide `boxLeft`, `boxTop`, `boxWidth`, `boxHeight`, and optional `paddingRatio`, and the runtime will deterministically translate that box into concrete crop/clipping controls.
 The runtime binds supported canonical actions to concrete darktable controls deterministically before applying them.
 Inside each apply_operations call, operations are auto-applied one at a time with a fresh render after each step.
 Turn input includes the current preview image, editable settings, and histogram.
@@ -33,5 +33,6 @@ Apply at least one edit batch within the first {{ apply_budget_window }} tool ca
 When satisfied, return final JSON with continueRefining=false and usually empty operations.
 In multi-turn mode the final JSON should summarize the run; continueRefining must be false.
 {% else %}Single-turn mode: do not call apply_operations; return raw operations directly in the final JSON for this path.
+To crop in this single-turn/raw path, set the 'crop' or 'clipping' module's normalized [0.0, 1.0] parameters directly: cx=left edge, cy=top edge, cw=right edge, ch=bottom edge. No crop = cx=0, cy=0, cw=1, ch=1. Example: bottom-right quadrant = cx=0.5, cy=0.5, cw=1.0, ch=1.0.
 {% endif %}Respect refinement state: treat passIndex/maxPasses as budget, set continueRefining=false once safe gains are exhausted.
 Return only the JSON object required by the output schema.

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -829,6 +829,9 @@ def test_turn_prompt_tells_codex_to_infer_broad_edit_plan_from_visual_context() 
     assert "you may pass `canonicalActions` to apply_operations" in prompt
     assert "adjust-exposure" in prompt
     assert "grade-color" in prompt
+    assert "crop-to-bounding-box" in prompt
+    assert "boxLeft" in prompt
+    assert "paddingRatio" in prompt
     assert "apply_operations returns the refreshed preview automatically" in prompt
     assert "operations are auto-applied one at a time" in prompt
     assert "Do not introduce new operations in the final JSON" in prompt
@@ -877,6 +880,27 @@ def test_turn_prompt_keeps_single_turn_instructions_separate_from_live_canonical
     assert "Single-turn mode: do not call apply_operations" in prompt
     assert "return raw operations directly in the final JSON" in prompt
     assert "you may pass `canonicalActions` to apply_operations" not in prompt
+    assert "To crop in this single-turn/raw path" in prompt
+    assert "cx=left edge" in prompt
+
+
+def test_crop_to_bounding_box_requires_box_coordinates() -> None:
+    with pytest.raises(ValueError, match="crop-to-bounding-box requires"):
+        AgentPlan.model_validate(
+            {
+                "assistantText": "Crop around the subject.",
+                "continueRefining": False,
+                "operations": [],
+                "canonicalActions": [
+                    {
+                        "action": "crop-to-bounding-box",
+                        "boxLeft": 0.2,
+                        "boxTop": 0.2,
+                        "boxWidth": 0.4,
+                    }
+                ],
+            }
+        )
 
 
 def test_canonical_binder_resolves_supported_actions_without_raw_ids() -> None:
@@ -946,6 +970,41 @@ def test_canonical_binder_resolves_supported_actions_without_raw_ids() -> None:
     assert bound_plan.operations[0].value.mode == "delta"
     assert bound_plan.operations[6].value.mode == "set"
     assert bound_plan.operations[6].value.number == pytest.approx(0.1)
+
+
+def test_canonical_binder_translates_bounding_box_crop_to_crop_controls() -> None:
+    request = _sample_request_with_canonical_controls()
+    plan = AgentPlan.model_validate(
+        {
+            "assistantText": "Crop around the subject.",
+            "continueRefining": False,
+            "operations": [],
+            "canonicalActions": [
+                {
+                    "action": "crop-to-bounding-box",
+                    "boxLeft": 0.2,
+                    "boxTop": 0.25,
+                    "boxWidth": 0.5,
+                    "boxHeight": 0.4,
+                    "paddingRatio": 0.1,
+                    "rationale": "Frame the subject with a little breathing room.",
+                }
+            ],
+        }
+    )
+
+    bound_plan = bind_canonical_plan(request, plan)
+
+    axis_values = {
+        operation.target.actionPath: operation.value.number
+        for operation in bound_plan.operations
+    }
+    assert axis_values == {
+        "iop/clipping/cx": pytest.approx(0.15),
+        "iop/clipping/cy": pytest.approx(0.21),
+        "iop/clipping/cw": pytest.approx(0.75),
+        "iop/clipping/ch": pytest.approx(0.69),
+    }
 
 
 def test_canonical_binder_surfaces_binding_failures_safely() -> None:
@@ -1684,6 +1743,78 @@ def test_apply_operations_tool_binds_canonical_actions_in_live_mode(
         assert turn_context.setting_by_id["setting.clipping.cx"][
             "currentNumber"
         ] == pytest.approx(0.1)
+    finally:
+        bridge._clear_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+
+
+def test_apply_operations_tool_binds_bounding_box_crop_in_live_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = CodexAppServerBridge(
+        command=["codex", "app-server", "--listen", "stdio://"]
+    )
+    request = _sample_request_with_canonical_controls()
+    data_url = bridge._preview_data_url(request)  # type: ignore[attr-defined]
+    bridge._register_turn_context("thread-1", "turn-1", request, data_url)  # type: ignore[attr-defined]
+    sent_payloads: list[dict] = []
+
+    def _capture(payload):  # type: ignore[no-untyped-def]
+        sent_payloads.append(payload)
+
+    bridge._send_json_locked = _capture  # type: ignore[method-assign,attr-defined]
+    try:
+        turn_context = bridge._get_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+        assert turn_context is not None
+
+        def _mock_wait(timeout=None, *, context=turn_context):
+            context.rendered_preview_bytes = b"fake-preview-stage-crop"
+            return True
+
+        monkeypatch.setattr(turn_context.render_event, "wait", _mock_wait)
+
+        bridge._handle_server_request_locked(  # type: ignore[attr-defined]
+            {
+                "jsonrpc": "2.0",
+                "id": 120,
+                "method": "item/tool/call",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "callId": "call-apply-crop-box",
+                    "tool": _TOOL_APPLY_OPERATIONS,
+                    "arguments": {
+                        "canonicalActions": [
+                            {
+                                "action": "crop-to-bounding-box",
+                                "boxLeft": 0.2,
+                                "boxTop": 0.25,
+                                "boxWidth": 0.5,
+                                "boxHeight": 0.4,
+                                "paddingRatio": 0.1,
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+        result = sent_payloads[0]["result"]
+        assert result["success"] is True
+        assert "Applied 4 operations" in result["contentItems"][0]["text"]
+        turn_context = bridge._get_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
+        assert turn_context is not None
+        assert turn_context.setting_by_id["setting.clipping.cx"][
+            "currentNumber"
+        ] == pytest.approx(0.15)
+        assert turn_context.setting_by_id["setting.clipping.cy"][
+            "currentNumber"
+        ] == pytest.approx(0.21)
+        assert turn_context.setting_by_id["setting.clipping.cw"][
+            "currentNumber"
+        ] == pytest.approx(0.75)
+        assert turn_context.setting_by_id["setting.clipping.ch"][
+            "currentNumber"
+        ] == pytest.approx(0.69)
     finally:
         bridge._clear_turn_context("thread-1", "turn-1")  # type: ignore[attr-defined]
 

--- a/shared/canonical_plan.py
+++ b/shared/canonical_plan.py
@@ -11,6 +11,7 @@ CanonicalActionName = Literal[
     "reduce-noise",
     "grade-color",
     "crop-normalized",
+    "crop-to-bounding-box",
 ]
 CanonicalStrength = Literal["low", "medium", "high"]
 CanonicalNoiseType = Literal["chroma", "luma", "both"]
@@ -40,6 +41,11 @@ class CanonicalEditAction(CanonicalBaseModel):
     top: float | None = None
     right: float | None = None
     bottom: float | None = None
+    boxLeft: float | None = None
+    boxTop: float | None = None
+    boxWidth: float | None = None
+    boxHeight: float | None = None
+    paddingRatio: float | None = None
     rationale: str | None = None
 
     @model_validator(mode="after")
@@ -91,4 +97,34 @@ class CanonicalEditAction(CanonicalBaseModel):
                 raise ValueError("crop-normalized left must be less than right")
             if self.top >= self.bottom:
                 raise ValueError("crop-normalized top must be less than bottom")
+        elif self.action == "crop-to-bounding-box":
+            bounds = (self.boxLeft, self.boxTop, self.boxWidth, self.boxHeight)
+            if any(value is None for value in bounds):
+                raise ValueError(
+                    "crop-to-bounding-box requires boxLeft, boxTop, boxWidth, and boxHeight"
+                )
+            assert self.boxLeft is not None
+            assert self.boxTop is not None
+            assert self.boxWidth is not None
+            assert self.boxHeight is not None
+            for label, value in (
+                ("boxLeft", self.boxLeft),
+                ("boxTop", self.boxTop),
+                ("boxWidth", self.boxWidth),
+                ("boxHeight", self.boxHeight),
+            ):
+                if not 0.0 <= value <= 1.0:
+                    raise ValueError(
+                        f"crop-to-bounding-box {label} must be within [0, 1]"
+                    )
+            if self.boxWidth <= 0.0:
+                raise ValueError("crop-to-bounding-box boxWidth must be greater than 0")
+            if self.boxHeight <= 0.0:
+                raise ValueError(
+                    "crop-to-bounding-box boxHeight must be greater than 0"
+                )
+            if self.paddingRatio is not None and not 0.0 <= self.paddingRatio <= 1.0:
+                raise ValueError(
+                    "crop-to-bounding-box paddingRatio must be within [0, 1]"
+                )
         return self


### PR DESCRIPTION
## Summary
- add a canonical `crop-to-bounding-box` action so the agent can express subject-centric crop intent without guessing raw crop edges
- deterministically translate bounding-box crops into concrete `crop`/`clipping` controls in the canonical binder, with optional padding and clamping
- add prompt guidance and coverage for multi-turn bounding-box crops while keeping single-turn crop instructions raw and separate

## Validation
- `uv run pytest server/tests`
- `uvx pyright server shared`
- `uvx pre-commit run --all-files`

Local smoke tests were intentionally not run; rely on GitHub Actions smoke coverage.

Closes #23