### PR TITLE
Fix apply_operations dynamic tool schema

### DIFF
--- a/server/codex_bridge/tool_routing.py
+++ b/server/codex_bridge/tool_routing.py
@@ -39,10 +39,6 @@ class ToolRoutingMixin:
                     "items": {"type": "object"},
                 },
             },
-            "anyOf": [
-                {"required": ["operations"]},
-                {"required": ["canonicalActions"]},
-            ],
             "additionalProperties": False,
         }
         get_playbook_schema = {

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -1389,6 +1389,7 @@ def test_get_or_create_thread_includes_native_dynamic_tools() -> None:
     apply_tool = next(
         tool for tool in tool_specs if tool["name"] == _TOOL_APPLY_OPERATIONS
     )
+    assert "anyOf" not in apply_tool["inputSchema"]
     assert "canonicalActions" in apply_tool["inputSchema"]["properties"]
 
 


### PR DESCRIPTION
## Summary
- remove the top-level `anyOf` from the `apply_operations` dynamic tool schema so Codex accepts the tool definition
- keep request validation in the existing `prepare_apply_batch` runtime checks
- add a regression assertion that the emitted schema does not contain a top-level `anyOf`

## Validation
- `./.venv/bin/pytest -q server/tests/test_codex_app_server.py -k "get_or_create_thread_includes_native_dynamic_tools"`
- `./.venv/bin/pytest -q server/tests/test_codex_app_server.py -k "apply_operations_tool_updates_state_and_stages_operations"`
