### PR TITLE
Fix duplicate canonical operation IDs during plan binding

### DIFF
--- a/darktable/src/gui/preferences.c
+++ b/darktable/src/gui/preferences.c
@@ -1502,6 +1502,66 @@ _gui_preferences_string_callback(GtkWidget *widget,
   dt_conf_set_string((char *)data, str);
 }
 
+static const char *_gui_preferences_dir_default_data_key = "dt-preferences-default-dir";
+
+static const char *_gui_preferences_dir_get_default(GtkWidget *widget)
+{
+  const char *default_dir = g_object_get_data(G_OBJECT(widget), _gui_preferences_dir_default_data_key);
+  if(default_dir) return default_dir;
+
+  const char *key = gtk_widget_get_name(widget);
+  return key ? dt_confgen_get(key, DT_DEFAULT) : "";
+}
+
+static gchar *_gui_preferences_dir_expand(const char *path)
+{
+  return (path && *path) ? dt_conf_expand_default_dir(path) : g_strdup("");
+}
+
+static void _gui_preferences_dir_open_chooser(GtkEntry *entry)
+{
+  GtkWindow *window = GTK_WINDOW(gtk_widget_get_toplevel(GTK_WIDGET(entry)));
+  GtkFileChooserNative *chooser = gtk_file_chooser_native_new(
+      _("select directory"), window, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_select"), _("_cancel"));
+
+  const char *current_path = gtk_entry_get_text(entry);
+  gchar *default_path = NULL;
+  if(current_path && *current_path)
+  {
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), current_path);
+  }
+  else
+  {
+    default_path = _gui_preferences_dir_expand(_gui_preferences_dir_get_default(GTK_WIDGET(entry)));
+    if(default_path[0])
+      gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), default_path);
+  }
+
+  if(gtk_native_dialog_run(GTK_NATIVE_DIALOG(chooser)) == GTK_RESPONSE_ACCEPT)
+  {
+    gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
+    if(folder)
+    {
+      gtk_entry_set_text(entry, folder);
+      g_free(folder);
+    }
+  }
+
+  g_free(default_path);
+  g_object_unref(chooser);
+}
+
+static void _gui_preferences_dir_icon_press(GtkEntry *entry,
+                                            GtkEntryIconPosition icon_pos,
+                                            GdkEvent *event,
+                                            gpointer user_data)
+{
+  (void)event;
+  (void)user_data;
+  if(icon_pos == GTK_ENTRY_ICON_SECONDARY)
+    _gui_preferences_dir_open_chooser(entry);
+}
+
 void dt_gui_preferences_string_reset(GtkWidget *widget)
 {
   const char *key = gtk_widget_get_name(widget);
@@ -1552,6 +1612,58 @@ GtkWidget *dt_gui_preferences_string(GtkGrid *grid,
                    G_CALLBACK(_gui_preferences_string_callback), (gpointer)key);
   g_signal_connect(G_OBJECT(labelev), "button-press-event",
                    G_CALLBACK(_gui_preferences_string_reset), (gpointer)w);
+  return w;
+}
+
+void dt_gui_preferences_dir_reset(GtkWidget *widget)
+{
+  const char *key = gtk_widget_get_name(widget);
+  const char *default_dir = _gui_preferences_dir_get_default(widget);
+  gchar *path = _gui_preferences_dir_expand(default_dir);
+  dt_conf_set_string(key, default_dir);
+  gtk_entry_set_text(GTK_ENTRY(widget), path);
+  g_free(path);
+}
+
+void dt_gui_preferences_dir_update(GtkWidget *widget)
+{
+  const char *key = gtk_widget_get_name(widget);
+  gchar *setting = dt_conf_get_string(key);
+  gchar *path = _gui_preferences_dir_expand(setting);
+  gtk_entry_set_text(GTK_ENTRY(widget), path);
+  g_free(path);
+  g_free(setting);
+}
+
+void dt_gui_preferences_dir_write(GtkWidget *widget)
+{
+  const char *key = gtk_widget_get_name(widget);
+  const char *path = gtk_entry_get_text(GTK_ENTRY(widget));
+  const char *default_dir = _gui_preferences_dir_get_default(widget);
+  gchar *default_path = _gui_preferences_dir_expand(default_dir);
+
+  if(!g_strcmp0(path, default_path))
+    dt_conf_set_string(key, default_dir);
+  else
+    dt_conf_set_string(key, path);
+
+  g_free(default_path);
+}
+
+GtkWidget *dt_gui_preferences_dir(GtkWidget *dialog, const char *key, const char *default_dir)
+{
+  GtkWidget *w = gtk_entry_new();
+  gtk_widget_set_name(w, key);
+  gtk_widget_set_halign(w, GTK_ALIGN_FILL);
+  gtk_widget_set_hexpand(w, TRUE);
+  gtk_editable_set_editable(GTK_EDITABLE(w), FALSE);
+  gtk_entry_set_icon_from_icon_name(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, "document-open-symbolic");
+  gtk_entry_set_icon_activatable(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, TRUE);
+  gtk_entry_set_icon_sensitive(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, TRUE);
+  gtk_entry_set_icon_tooltip_text(GTK_ENTRY(w), GTK_ENTRY_ICON_SECONDARY, _("select directory"));
+  g_object_set_data_full(G_OBJECT(w), _gui_preferences_dir_default_data_key, g_strdup(default_dir), g_free);
+  dt_gui_preferences_dir_update(w);
+  g_signal_connect(G_OBJECT(w), "icon-press", G_CALLBACK(_gui_preferences_dir_icon_press), dialog);
   return w;
 }
 

--- a/darktable/src/gui/preferences.h
+++ b/darktable/src/gui/preferences.h
@@ -29,20 +29,23 @@ GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint co
 GtkWidget *dt_gui_preferences_enum(dt_action_t *action, const char *key);
 GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint col,
                                      const guint line);
+GtkWidget *dt_gui_preferences_dir(GtkWidget *dialog, const char *key, const char *default_dir);
 
 // update widget with current preference
 void dt_gui_preferences_bool_update(GtkWidget *widget);
 void dt_gui_preferences_int_update(GtkWidget *widget);
 void dt_gui_preferences_string_update(GtkWidget *widget);
+void dt_gui_preferences_dir_update(GtkWidget *widget);
 
 // reset widget to default value
 void dt_gui_preferences_bool_reset(GtkWidget *widget);
 void dt_gui_preferences_int_reset(GtkWidget *widget);
 void dt_gui_preferences_string_reset(GtkWidget *widget);
+void dt_gui_preferences_dir_reset(GtkWidget *widget);
+void dt_gui_preferences_dir_write(GtkWidget *widget);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/darktable/tools/generate_prefs.xsl
+++ b/darktable/tools/generate_prefs.xsl
@@ -84,15 +84,19 @@ static void set_widget_label_default(GtkWidget *widget,
   }
   else if(GTK_IS_ENTRY(widget))
   {
-    const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
     const gchar *c_state = gtk_entry_get_text(GTK_ENTRY(widget));
-    is_default = (g_strcmp0(c_state, c_default) == 0);
-  }
-  else if(GTK_IS_FILE_CHOOSER(widget))
-  {
-    const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
-    const gchar *c_state = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
-    is_default = (g_strcmp0(c_state, c_default) == 0);
+    if(dt_confgen_type(confstr) == DT_PATH)
+    {
+      const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
+      gchar *p_default = dt_conf_expand_default_dir(c_default);
+      is_default = (g_strcmp0(c_state, p_default) == 0);
+      g_free(p_default);
+    }
+    else
+    {
+      const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
+      is_default = (g_strcmp0(c_state, c_default) == 0);
+    }
   }
   else
   {
@@ -142,8 +146,21 @@ static GtkWidget *setup_pref(GtkWidget **label,
                              const gchar *shortdes)
 {
   const gboolean is_default = dt_conf_is_default(pref);
+  gboolean show_default = is_default;
+  if(!show_default && dt_confgen_type(pref) == DT_PATH)
+  {
+    const gchar *c_default = dt_confgen_get(pref, DT_DEFAULT);
+    const gchar *c_state = dt_conf_get_string_const(pref);
+    gchar *p_default = dt_conf_expand_default_dir(c_default);
+    gchar *p_state = dt_conf_expand_default_dir(c_state ? c_state : c_default);
+    show_default = (g_strcmp0(p_state, p_default) == 0);
+    if(show_default)
+      dt_conf_set_string(pref, c_default);
+    g_free(p_state);
+    g_free(p_default);
+  }
   GtkWidget *labdef = NULL;
-  if(is_default)
+  if(show_default)
   {
     labdef = gtk_label_new("");
   }
@@ -488,12 +505,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
 
   <xsl:template match="dtconfig[type='dir']" mode="reset">
     <xsl:text>
-    gchar *path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
-    dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", path);
-    g_free(path);
-    path = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
-    gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(widget), path);
-    g_free(path);</xsl:text>
+    dt_gui_preferences_dir_reset(widget);</xsl:text>
   </xsl:template>
 
 <!-- CHANGE -->
@@ -544,9 +556,7 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
 
   <xsl:template match="dtconfig[type='dir']" mode="change">
   <xsl:text>
-    gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
-    dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", folder);
-    g_free(folder);</xsl:text>
+    dt_gui_preferences_dir_write(widget);</xsl:text>
   </xsl:template>
 
 <!-- TAB -->
@@ -583,14 +593,8 @@ static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
 
   <xsl:template match="dtconfig[type='dir']" mode="tab">
     <xsl:text>
-    widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
-    gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(widget), 20);
-    gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
-    gtk_widget_set_hexpand(widget, TRUE);
-    gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget), setting);
-    g_free(setting);
-    g_signal_connect(G_OBJECT(widget), "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
+    widget = dt_gui_preferences_dir(dialog, "</xsl:text><xsl:value-of select="name"/><xsl:text>", "</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     gchar *default_path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), default_path);

--- a/server/codex_bridge/canonical_binder.py
+++ b/server/codex_bridge/canonical_binder.py
@@ -29,14 +29,7 @@ def bind_canonical_plan(request: RequestEnvelope, plan: AgentPlan) -> AgentPlan:
         operation.model_dump(mode="json") for operation in plan.operations
     ] + bound_operations
 
-    normalized_operations: list[dict[str, object]] = []
-    for index, operation in enumerate(combined_operations, start=1):
-        operation_copy = dict(operation)
-        operation_copy["operationId"] = str(
-            operation_copy.get("operationId") or f"canonical-op-{index}"
-        )
-        operation_copy["sequence"] = index
-        normalized_operations.append(operation_copy)
+    normalized_operations = _normalize_operations_with_unique_ids(combined_operations)
 
     assistant_text = plan.assistantText
     if failures:
@@ -78,16 +71,33 @@ def bind_canonical_actions(
         bound_operations.extend(result.operations)
         failures.extend(result.failures)
 
+    return _BindingResult(
+        _normalize_operations_with_unique_ids(bound_operations), failures
+    )
+
+
+def _normalize_operations_with_unique_ids(
+    operations: list[dict[str, object]],
+) -> list[dict[str, object]]:
     normalized_operations: list[dict[str, object]] = []
-    for index, operation in enumerate(bound_operations, start=1):
+    seen_operation_ids: set[str] = set()
+
+    for index, operation in enumerate(operations, start=1):
         operation_copy = dict(operation)
-        operation_copy["operationId"] = str(
+        candidate_operation_id = str(
             operation_copy.get("operationId") or f"canonical-op-{index}"
         )
+        operation_id = candidate_operation_id
+        duplicate_index = 2
+        while operation_id in seen_operation_ids:
+            operation_id = f"{candidate_operation_id}-{duplicate_index}"
+            duplicate_index += 1
+        seen_operation_ids.add(operation_id)
+        operation_copy["operationId"] = operation_id
         operation_copy["sequence"] = index
         normalized_operations.append(operation_copy)
 
-    return _BindingResult(normalized_operations, failures)
+    return normalized_operations
 
 
 def _bind_action(

--- a/server/tests/test_codex_app_server.py
+++ b/server/tests/test_codex_app_server.py
@@ -1042,6 +1042,77 @@ def test_canonical_binder_translates_bounding_box_crop_to_crop_controls() -> Non
     }
 
 
+def test_canonical_binder_deduplicates_ids_for_repeated_bound_settings() -> None:
+    request = _sample_request_with_canonical_controls()
+    plan = AgentPlan.model_validate(
+        {
+            "assistantText": "Lift exposure twice.",
+            "continueRefining": False,
+            "operations": [],
+            "canonicalActions": [
+                {
+                    "action": "adjust-exposure",
+                    "exposureEv": 0.2,
+                },
+                {
+                    "action": "adjust-exposure",
+                    "exposureEv": 0.3,
+                },
+            ],
+        }
+    )
+
+    bound_plan = bind_canonical_plan(request, plan)
+
+    assert [operation.operationId for operation in bound_plan.operations] == [
+        "bind-setting.exposure.primary",
+        "bind-setting.exposure.primary-2",
+    ]
+    assert [operation.sequence for operation in bound_plan.operations] == [1, 2]
+
+
+def test_canonical_binder_deduplicates_ids_across_raw_and_bound_operations() -> None:
+    request = _sample_request_with_canonical_controls()
+    plan = AgentPlan.model_validate(
+        {
+            "assistantText": "Keep the existing operation and bind another.",
+            "continueRefining": False,
+            "operations": [
+                {
+                    "operationId": "bind-setting.exposure.primary",
+                    "sequence": 1,
+                    "kind": "set-float",
+                    "target": {
+                        "type": "darktable-action",
+                        "actionPath": "iop/exposure/exposure",
+                        "settingId": "setting.exposure.primary",
+                    },
+                    "value": {"mode": "delta", "number": 0.1},
+                    "reason": None,
+                    "constraints": {
+                        "onOutOfRange": "clamp",
+                        "onRevisionMismatch": "fail",
+                    },
+                }
+            ],
+            "canonicalActions": [
+                {
+                    "action": "adjust-exposure",
+                    "exposureEv": 0.2,
+                }
+            ],
+        }
+    )
+
+    bound_plan = bind_canonical_plan(request, plan)
+
+    assert [operation.operationId for operation in bound_plan.operations] == [
+        "bind-setting.exposure.primary",
+        "bind-setting.exposure.primary-2",
+    ]
+    assert [operation.sequence for operation in bound_plan.operations] == [1, 2]
+
+
 def test_canonical_binder_surfaces_binding_failures_safely() -> None:
     request = _sample_request()
     plan = AgentPlan.model_validate(


### PR DESCRIPTION
## Summary
- deduplicate canonical-bound operation IDs before `AgentPlan` revalidation
- reuse the same normalization path when binding canonical actions directly and when merging raw operations with bound canonical operations
- add regression tests for repeated canonical edits on the same setting and raw-plus-canonical ID collisions

## Problem
Live refinement could partially succeed, apply edits, and then fail when `bind_canonical_plan()` rebuilt the final `AgentPlan`. The binder preserved existing `operationId` values and generated `bind-{settingId}` IDs for canonical operations, so duplicate IDs could be introduced during merge and rejected by strict plan validation.

## Testing
- `.venv/bin/pytest server/tests/test_codex_app_server.py -k 'canonical_binder or finalize_plan_with_live_context'`
- `.venv/bin/pytest server/tests/test_protocol.py -k 'duplicate_operation_ids'`