### PR TITLE
Expose darktable compile commands for LSP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ uv.lock
 darktable/build/
 darktable/build-*/
 darktable/.install-*/
+darktable/compile_commands.json
 darktable/Testing/
 .darktable-local/
 assets/*.xmp

--- a/darktable/CMakeLists.txt
+++ b/darktable/CMakeLists.txt
@@ -38,6 +38,13 @@ endif()
 include(DefineOptions.cmake)
 include(CTest)
 
+if(CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(DARKTABLE_COMPILE_COMMANDS_LINK "${CMAKE_SOURCE_DIR}/compile_commands.json")
+  file(REMOVE "${DARKTABLE_COMPILE_COMMANDS_LINK}")
+  file(CREATE_LINK "${CMAKE_BINARY_DIR}/compile_commands.json"
+       "${DARKTABLE_COMPILE_COMMANDS_LINK}" SYMBOLIC COPY_ON_ERROR)
+endif()
+
 # Include GNUInstallDirs, which sets sensible defaults for install directories.
 # See https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html for further information.
 # These values can be easily overridden if required.


### PR DESCRIPTION
Closes #61

## Summary
- surface `darktable/compile_commands.json` from the configured CMake build directory so `clangd` can discover it from files under `darktable/src/...`
- keep the generated source-tree link out of git with a `.gitignore` entry
- leave darktable's existing `CMAKE_EXPORT_COMPILE_COMMANDS` behavior intact and just make the result editor-discoverable

## Verification
- `cmake -S /Users/cgas/Documents/Projects/darktableAgent/darktable -B /Users/cgas/Documents/Projects/darktableAgent/darktable/build-5.4.1`
- `cmake --build /Users/cgas/Documents/Projects/darktableAgent/darktable/build-5.4.1 --target before_after snapshots -j4`

## Notes
- after reconfiguring, the build now creates `darktable/compile_commands.json` pointing at the active build directory's compilation database
- editors may still need a file reload or language-server restart to pick up the new path