### PR TITLE
Fix macOS app launcher schema setup

### DIFF
--- a/darktable/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/darktable/packaging/macosx/3_make_hb_darktable_package.sh
@@ -22,7 +22,7 @@ dtAppName="darktable"
 dtWorkingDir="$dtPackageDir"/"$dtAppName".app
 dtResourcesDir="$dtWorkingDir"/Contents/Resources
 dtExecDir="$dtWorkingDir"/Contents/MacOS
-dtExecutables=$(echo "$dtExecDir"/darktable{,-chart,-cli,-cltest,-generate-cache,-rs-identify,-curve-tool,-noiseprofile})
+dtExecutables="$dtExecDir/darktable-bin $dtExecDir/darktable-chart $dtExecDir/darktable-cli $dtExecDir/darktable-cltest $dtExecDir/darktable-generate-cache $dtExecDir/darktable-rs-identify $dtExecDir/darktable-curve-tool $dtExecDir/darktable-noiseprofile"
 homebrewHome=$(brew --prefix)
 
 
@@ -216,6 +216,9 @@ gtk-icon-theme-name = Adwaita
 
 # Add darktable executables
 cp "$buildDir"/bin/darktable{,-chart,-cli,-cltest,-generate-cache,-rs-identify} "$dtExecDir"/
+mv "$dtExecDir"/darktable "$dtExecDir"/darktable-bin
+cp darktable-launcher.sh "$dtExecDir"/darktable
+chmod +x "$dtExecDir"/darktable
 
 # Add darktable tools if existent
 if [[ -d "$buildDir"/libexec/darktable/tools ]]; then

--- a/darktable/packaging/macosx/darktable-launcher.sh
+++ b/darktable/packaging/macosx/darktable-launcher.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+resources_dir=$(CDPATH= cd -- "$script_dir/../Resources" && pwd)
+share_dir="$resources_dir/share"
+schema_dir="$share_dir/glib-2.0/schemas"
+binary="$script_dir/darktable-bin"
+
+if [ ! -x "$binary" ]; then
+  printf '%s\n' "darktable launcher error: missing executable $binary" >&2
+  exit 1
+fi
+
+if [ -d "$schema_dir" ]; then
+  export GSETTINGS_SCHEMA_DIR="$schema_dir"
+fi
+
+if [ -d "$share_dir" ]; then
+  export XDG_DATA_DIRS="$share_dir${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+fi
+
+exec "$binary" "$@"

--- a/darktable/packaging/macosx/make-app-bundle
+++ b/darktable/packaging/macosx/make-app-bundle
@@ -6,14 +6,15 @@ cd "$(dirname "$0")"/
 lensfun-update-data || true
 cp -R ~/.local/share/lensfun .
 ~/.local/bin/gtk-mac-bundler darktable.bundle
-mv package/darktable.app/Contents/MacOS/darktable-bin package/darktable.app/Contents/MacOS/darktable
+cp darktable-launcher.sh package/darktable.app/Contents/MacOS/darktable
+chmod +x package/darktable.app/Contents/MacOS/darktable
 mv package/darktable.app/Contents/Resources/lib/gdk-pixbuf-2.0/*/loaders.cache package/darktable.app/Contents/Resources/etc/gtk-3.0/
 rm -Rf lensfun
 sed -i '' 's|/opt/local/share/locale||' package/darktable.app/Contents/Resources/etc/gtk-3.0/gtk.immodules
 glib-compile-schemas package/darktable.app/Contents/Resources/share/glib-2.0/schemas/
 sed -i '' 's|{VERSION}|'$(git describe --tags --long --match '*[0-9.][0-9.][0-9]'|cut -d- -f2|sed 's/^\([0-9]*\.[0-9]*\)$/\1.0/')'|' package/darktable.app/Contents/Info.plist
 sed -i '' 's|{COMMITS}|'$(git describe --tags --long --match '*[0-9.][0-9.][0-9]'|cut -d- -f3)'|' package/darktable.app/Contents/Info.plist
-for i in package/darktable.app/Contents/MacOS/darktable{,-chart,-cli,-cltest,-generate-cache}
+for i in package/darktable.app/Contents/MacOS/darktable-bin{,-chart,-cli,-cltest,-generate-cache}
 do
 	install_name_tool -rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable "$i"
 done
@@ -22,7 +23,7 @@ ln -s /Applications package/
 if [ -z "$STRIPDEBUGINFO" ]
 then
 	find package/darktable.app/Contents/Resources/lib/darktable \( -name \*.dylib -or -name \*.so \) -exec dsymutil \{} \;
-	for i in package/darktable.app/Contents/MacOS/darktable{,-chart,-cli,-cltest,-generate-cache,-curve-tool,-noiseprofile}
+	for i in package/darktable.app/Contents/MacOS/darktable-bin{,-chart,-cli,-cltest,-generate-cache,-curve-tool,-noiseprofile}
 	do
 		dsymutil "$i"
 	done


### PR DESCRIPTION
## Summary
- add a macOS app launcher wrapper that points GTK at the bundle's own schema and share directories before starting `darktable-bin`
- keep the real GUI binary as `darktable-bin` in both macOS packaging flows and update post-processing steps to target that binary
- prevent bundled darktable from crashing when GTK creates the native file chooser without Homebrew GLib paths in the ambient environment

## Verification
- `bash -n darktable/packaging/macosx/darktable-launcher.sh`
- `bash -n darktable/packaging/macosx/make-app-bundle`
- `bash -n darktable/packaging/macosx/3_make_hb_darktable_package.sh`